### PR TITLE
fix: added the modal hooks to the export

### DIFF
--- a/module/src/components/modal/index.ts
+++ b/module/src/components/modal/index.ts
@@ -1,2 +1,3 @@
 export * from './modal.component';
 export * from './modal.context';
+export * from './modal.hooks';


### PR DESCRIPTION
## What's new?

- Added `export * from './modal.hooks';` to the modal component

## Checklist

N/A
