### PR TITLE
fix: removing inconsistent date-fns imports

### DIFF
--- a/module/src/components/timeInput/timeInput.utils.ts
+++ b/module/src/components/timeInput/timeInput.utils.ts
@@ -1,6 +1,4 @@
-import { addMinutes, getHours, getMinutes, isValid, parse, startOfDay } from 'date-fns';
-import { addHours } from 'date-fns/esm';
-import format from 'date-fns/format';
+import { addHours, addMinutes, format, getHours, getMinutes, isValid, parse, startOfDay } from 'date-fns';
 
 import { Dates } from '../../utils/dates';
 import { ISelectOption } from '../select';


### PR DESCRIPTION
Without the correct loader importing from `date-fns/esm` throws this cool error 

```
SyntaxError: Unexpected token export
    at Module._compile (internal/modules/cjs/loader.js:723:23)
    at Object.Module._extensions..js 
``` 
