### PR TITLE
fix: fixed dialogs closing when dragging from inside to outside

### DIFF
--- a/module/src/components/modal/modal.component.tsx
+++ b/module/src/components/modal/modal.component.tsx
@@ -122,7 +122,7 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       <Portal portalTo={portalTo || (!portalToSelector && wrapperRef) || undefined} portalToSelector={portalToSelector}>
         <div
           className={ClassNames.concat('arm-modal-wrapper', wrapperClassName)}
-          onClick={onClickWrapperEvent}
+          onMouseDown={onClickWrapperEvent}
           data-close-on-background-click={!!closeOnBackgroundClick}
           data-darken-background={darkenBackground}
           data-is-closing={isClosing}


### PR DESCRIPTION
## What's new?

Fixed https://github.com/Rocketmakers/armstrong-edge/issues/45 by changing the modal wrapper `onClick` event to a `onMouseDown` so it doesn't incorrectly pick up mouse up events caused by dragging selections from within the dialog
