### PR TITLE
feat: calendar input bug fixes

### DIFF
--- a/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
@@ -107,7 +107,7 @@ export const AutoCompleteInput = React.forwardRef(
 
     const [optionsOpen, setOptionsOpen] = React.useState(false);
 
-    const [isFocused, isFocusedProps] = useIsFocused({ onBlur: textInputProps?.onBlur, onFocus: textInputProps?.onFocus });
+    const [isFocused, isFocusedProps] = useIsFocused({ onBlur: textInputProps.onBlur, onFocus: textInputProps.onFocus });
 
     // log a piece of state to manage whether the options dropdown has just been opened, and no filtering has occurred
     const [justOpened, setJustOpened] = React.useState(optionsOpen);

--- a/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
@@ -107,7 +107,7 @@ export const AutoCompleteInput = React.forwardRef(
 
     const [optionsOpen, setOptionsOpen] = React.useState(false);
 
-    const [isFocused, isFocusedProps] = useIsFocused();
+    const [isFocused, isFocusedProps] = useIsFocused({ onBlur: textInputProps?.onBlur, onFocus: textInputProps?.onFocus });
 
     // log a piece of state to manage whether the options dropdown has just been opened, and no filtering has occurred
     const [justOpened, setJustOpened] = React.useState(optionsOpen);

--- a/module/src/components/calendarInput/calendarInput.component.tsx
+++ b/module/src/components/calendarInput/calendarInput.component.tsx
@@ -236,7 +236,7 @@ export const CalendarInput = React.forwardRef(
         }
 
         if (bind?.myValidationErrors?.length === 1 && bind.myValidationErrors[0].message === invalidDateMessage) {
-          bind?.clearValidationErrors();
+          bind.clearValidationErrors();
         }
 
         const date = new Date(year, month, day);

--- a/module/src/components/calendarInput/calendarInput.component.tsx
+++ b/module/src/components/calendarInput/calendarInput.component.tsx
@@ -223,18 +223,21 @@ export const CalendarInput = React.forwardRef(
     // when the value of the internal form changes, update the selected date
     React.useEffect(() => {
       // if parts of the date are omitted in inputOrder, use 1 or the given default
-      const day = formState?.day || (missingParts.includes('day') && (defaultIfOmitted?.day || 1));
-      const month = formState?.month || (missingParts.includes('month') && (defaultIfOmitted?.month || 1));
-      const year = formState?.year || (missingParts.includes('year') && (defaultIfOmitted?.year || 1));
+      const day = formState?.day ?? (missingParts.includes('day') && (defaultIfOmitted?.day ?? 1));
+      const month = formState?.month ?? (missingParts.includes('month') && (defaultIfOmitted?.month ?? 0));
+      const year = formState?.year ?? (missingParts.includes('year') && (defaultIfOmitted?.year ?? new Date().getFullYear()));
 
       // only bind if all parts that are included in
       if (typeof day === 'number' && typeof month === 'number' && typeof year === 'number') {
+        const invalidDateMessage = 'Invalid date selection';
         if (!validateDateSelection(day, month, year)) {
-          bind?.addValidationError('Invalid date selection');
+          bind?.addValidationError(invalidDateMessage);
           return;
         }
 
-        bind?.clearValidationErrors();
+        if (bind?.myValidationErrors?.length === 1 && bind.myValidationErrors[0].message === invalidDateMessage) {
+          bind?.clearValidationErrors();
+        }
 
         const date = new Date(year, month, day);
         if (!selectedDate || !isSameDay(date, Dates.dateLikeToDate(selectedDate, formatString, locale)!)) {

--- a/module/src/hooks/useIsFocused.ts
+++ b/module/src/hooks/useIsFocused.ts
@@ -1,27 +1,31 @@
 import * as React from 'react';
 
-import { useEventListener } from './useEventListener';
-
-export type UseIsFocusedReturn = [boolean, Pick<React.HTMLAttributes<HTMLElement>, 'onFocus' | 'onBlur'>];
+export type FocusBlurListeners<T extends HTMLElement> = Pick<React.HTMLAttributes<T>, 'onFocus' | 'onBlur'>;
+export type UseIsFocusedReturn<T extends HTMLElement> = [boolean, FocusBlurListeners<T>];
 
 /**
  * Get, in React state, whether an element is being focused.
- * Can be used by spreading the props returned from the second element in the returned array onto the element you want to listen to,
- * or by passing in a ref
+ * Can be used by spreading the props returned from the second element in the returned array onto the element you want to listen to
+ * @param listeners Option to pass native focus and blur listeners to be called when events fire.
  */
-export const useIsFocused = (ref?: React.MutableRefObject<Element | undefined | null>): UseIsFocusedReturn => {
+export const useIsFocused = <T extends HTMLElement>(listeners: FocusBlurListeners<T> = {}): UseIsFocusedReturn<T> => {
   const [isFocused, setIsFocused] = React.useState(false);
 
-  const onFocus = React.useCallback(() => {
-    setIsFocused(true);
-  }, []);
+  const onFocus = React.useCallback(
+    (event: React.FocusEvent<T>) => {
+      setIsFocused(true);
+      return listeners?.onFocus?.(event);
+    },
+    [listeners?.onFocus]
+  );
 
-  const onBlur = React.useCallback(() => {
-    setIsFocused(false);
-  }, []);
-
-  useEventListener('focus', onFocus, ref?.current || undefined);
-  useEventListener('blur', onBlur, ref?.current || undefined);
+  const onBlur = React.useCallback(
+    (event: React.FocusEvent<T>) => {
+      setIsFocused(false);
+      return listeners?.onBlur?.(event);
+    },
+    [listeners?.onBlur]
+  );
 
   return [isFocused, { onFocus, onBlur }];
 };


### PR DESCRIPTION
## What's new?

- Fixed a bug in the calendar input preventing January from being selected.
- Fixed a bug in the calendar input meaning client side validation was being cleared every render.
- Fixed a bug in autocomplete input preventing native focus and blur event support

## Ticket number(s) in JIRA (if internal)

N/A

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [✅] are your changes in Storybook?
- [✅] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [✅] does _everything_ have jsdoc?
- [✅] is everything exported from index.ts?
- [✅] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [✅] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [✅] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
