### PR TITLE
fix: add scss sideffects so storybook styling works again

### DIFF
--- a/module/package.json
+++ b/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketmakers/armstrong-edge",
-  "sideEffects": false,
+  "sideEffects": ["*.scss"],
   "version": "0.0.0-development",
   "description": "Armstrong is a React component library made by Rocketmakers written in Typescript and SCSS.",
   "main": "./dist/index.js",


### PR DESCRIPTION
## What's new?

Added an `scss` sideeffect so styling isn't excluded from storybook
