### PR TITLE
feature/deprecate-useBindingTools (rename to useBindingState)

### DIFF
--- a/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
@@ -96,7 +96,7 @@ export const AutoCompleteInput = React.forwardRef(
     }: IAutoCompleteInputProps<Id>,
     ref
   ) => {
-    const [boundValue, setBoundValue, { getFormattedValueFromData, validationErrorMessages: myValidationErrorMessages }] = Form.useBindingTools(
+    const [boundValue, setBoundValue, { getFormattedValueFromData, validationErrorMessages: myValidationErrorMessages }] = Form.useBindingState(
       bind,
       {
         value,

--- a/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.component.tsx
+++ b/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.component.tsx
@@ -67,7 +67,7 @@ export const AutoCompleteInputMulti = React.forwardRef(
     }: IAutoCompleteInputMultiProps<Id>,
     ref
   ) => {
-    const [boundValue, setBoundValue, { getFormattedValueFromData, validationErrorMessages: myValidationErrorMessages }] = Form.useBindingTools(
+    const [boundValue, setBoundValue, { getFormattedValueFromData, validationErrorMessages: myValidationErrorMessages }] = Form.useBindingState(
       bind,
       {
         value,

--- a/module/src/components/calendarInput/calendarInput.component.tsx
+++ b/module/src/components/calendarInput/calendarInput.component.tsx
@@ -174,7 +174,7 @@ export const CalendarInput = React.forwardRef(
     }: ICalendarInputProps<TValue>,
     ref: React.ForwardedRef<HTMLInputElement>
   ) => {
-    const [selectedDate, setSelectedDate, bindConfig] = Form.useBindingTools(bind, {
+    const [selectedDate, setSelectedDate, bindConfig] = Form.useBindingState(bind, {
       validationErrorMessages,
       validationMode,
       validationErrorIcon: errorIcon,

--- a/module/src/components/characterLimit/characterLimit.component.tsx
+++ b/module/src/components/characterLimit/characterLimit.component.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { IBindingProps, useBindingTools } from '../../hooks/form';
+import { IBindingProps, useBindingState } from '../../hooks/form';
 import { ClassNames } from '../../utils/classNames';
 import { Icon, IconSet, IconUtils, IIcon } from '../icon';
 
@@ -26,7 +26,7 @@ export interface ICharacterLimitProps {
 
 /** Render a character limit from a bound value, showing as an error if the user  */
 export const CharacterLimit: React.FC<ICharacterLimitProps> = ({ bind, limit, shouldEnforce, value, className, exceedsIcon }) => {
-  const [boundValue, setBoundValue] = useBindingTools(bind, { value });
+  const [boundValue, setBoundValue] = useBindingState(bind, { value });
 
   const exceeded = boundValue && boundValue.length > limit;
 

--- a/module/src/components/checkboxInput/checkboxInput.component.tsx
+++ b/module/src/components/checkboxInput/checkboxInput.component.tsx
@@ -71,7 +71,7 @@ export const CheckboxInput = React.forwardRef<HTMLInputElement, ICheckboxInputPr
     }: ICheckboxInputProps,
     ref
   ) => {
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value: checked,
       validationErrorMessages,
       validationErrorIcon: errorIcon,

--- a/module/src/components/checkboxInputList/checkboxInputList.component.tsx
+++ b/module/src/components/checkboxInputList/checkboxInputList.component.tsx
@@ -60,7 +60,7 @@ export const CheckboxInputList = React.forwardRef(
     }: ICheckboxInputListProps<Id>,
     ref
   ) => {
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       validationErrorIcon: errorIcon,
       validationErrorMessages,
       validationMode,

--- a/module/src/components/codeInput/codeInput.component.tsx
+++ b/module/src/components/codeInput/codeInput.component.tsx
@@ -133,7 +133,7 @@ export const CodeInput = React.forwardRef<HTMLDivElement, ICodeInputProps>(
   ) => {
     const inputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
 
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value,
       onChange,
       validationErrorMessages,

--- a/module/src/components/confirmPasswordInput/confirmPasswordInput.component.tsx
+++ b/module/src/components/confirmPasswordInput/confirmPasswordInput.component.tsx
@@ -14,7 +14,7 @@ export const ConfirmPasswordInput = React.forwardRef<HTMLInputElement, IConfirmP
     { passwordsDontMatchMessage, errorIcon, bind, validationMode, value, onFocus: onFocusProp, onBlur: onBlurProp, onValueChange, ...inputProps },
     ref
   ) => {
-    const [boundValue, , bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, , bindConfig] = Form.useBindingState(bind, {
       value: value?.toString(),
       onChange: onValueChange,
       validationMode,

--- a/module/src/components/dateTimeInput/dateTimeInput.component.tsx
+++ b/module/src/components/dateTimeInput/dateTimeInput.component.tsx
@@ -2,7 +2,7 @@ import { isSameMinute, isValid } from 'date-fns';
 import * as React from 'react';
 
 import { Form } from '../..';
-import { IBindingProps, useBindingTools } from '../../hooks/form';
+import { IBindingProps, useBindingState } from '../../hooks/form';
 import { ClassNames, Dates } from '../../utils';
 import { CalendarInput, ICalendarInputProps } from '../calendarInput';
 import { InputWrapper } from '../inputWrapper';
@@ -73,7 +73,7 @@ export const DateTimeInput = React.forwardRef(
     }: IDateTimeInputProps<TValue>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const [selectedDateTime, setSelectedDateTime, bindConfig] = useBindingTools(bind, {
+    const [selectedDateTime, setSelectedDateTime, bindConfig] = useBindingState(bind, {
       validationErrorIcon: errorIcon,
       validationErrorMessages,
       validationMode,

--- a/module/src/components/input/input.component.tsx
+++ b/module/src/components/input/input.component.tsx
@@ -92,7 +92,7 @@ export const Input = React.forwardRef<HTMLInputElement, IInputProps<any>>(
     const internalRef = React.useRef<HTMLInputElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!, [internalRef]);
 
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value: value?.toString(),
       validationErrorMessages,
       validationMode,

--- a/module/src/components/listBox/listBox.component.tsx
+++ b/module/src/components/listBox/listBox.component.tsx
@@ -83,7 +83,7 @@ export const ListBox = React.forwardRef(
     const internalRef = React.useRef<HTMLInputElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!, [internalRef]);
 
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value,
       validationErrorMessages,
       validationErrorIcon,

--- a/module/src/components/listBoxMulti/listBoxMulti.component.tsx
+++ b/module/src/components/listBoxMulti/listBoxMulti.component.tsx
@@ -67,7 +67,7 @@ export const ListBoxMulti = React.forwardRef(
     const internalRef = React.useRef<HTMLInputElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!, [internalRef]);
 
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value,
       validationErrorMessages,
       validationErrorIcon,

--- a/module/src/components/radioInputList/radioInputList.component.tsx
+++ b/module/src/components/radioInputList/radioInputList.component.tsx
@@ -60,7 +60,7 @@ export const RadioInputList = React.forwardRef(
     }: IRadioInputListProps<Id>,
     ref
   ) => {
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value,
       validationErrorMessages,
       validationErrorIcon: errorIcon,

--- a/module/src/components/rangeInput/rangeInput.component.tsx
+++ b/module/src/components/rangeInput/rangeInput.component.tsx
@@ -59,7 +59,7 @@ export const RangeInput = React.forwardRef<HTMLInputElement, IRangeInputProps>(
     },
     ref
   ) => {
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value,
       onChange: onValueChange,
       validationErrorMessages,

--- a/module/src/components/select/select.component.tsx
+++ b/module/src/components/select/select.component.tsx
@@ -78,7 +78,7 @@ export const Select = React.forwardRef(
     const internalRef = React.useRef<HTMLSelectElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!, [internalRef]);
 
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, { value, validationErrorMessages });
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, { value, validationErrorMessages });
 
     const clearSelect = React.useCallback(() => {
       onSelectOption?.(undefined);

--- a/module/src/components/switchInput/switchInput.component.tsx
+++ b/module/src/components/switchInput/switchInput.component.tsx
@@ -67,7 +67,7 @@ export const SwitchInput = React.forwardRef<HTMLInputElement, ISwitchInputProps>
     },
     ref
   ) => {
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value: checked,
       validationErrorMessages,
       onChange,

--- a/module/src/components/tabSelect/tabSelect.component.tsx
+++ b/module/src/components/tabSelect/tabSelect.component.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { IBindingProps, useBindingTools } from '../../hooks/form';
+import { IBindingProps, useBindingState } from '../../hooks/form';
 import { ArmstrongId } from '../../types/core';
 import { ClassNames } from '../../utils/classNames';
 import { IInputWrapperProps } from '../inputWrapper';
@@ -45,7 +45,7 @@ export const TabSelect = React.forwardRef(
     }: ITabSelectProps<Id>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const [boundValue, setBoundValue, bindConfig] = useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = useBindingState(bind, {
       onChange: onValueChange,
       value,
       validationErrorMessages,

--- a/module/src/components/tagInput/tagInput.component.tsx
+++ b/module/src/components/tagInput/tagInput.component.tsx
@@ -116,7 +116,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, ITagInputProps>(
     const internalRef = React.useRef<HTMLInputElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!, [internalRef]);
 
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value,
       onChange,
       validationErrorMessages,

--- a/module/src/components/textArea/textArea.component.tsx
+++ b/module/src/components/textArea/textArea.component.tsx
@@ -94,7 +94,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, ITextAreaProps>(
     const internalRef = React.useRef<HTMLTextAreaElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!, [internalRef]);
 
-    const [boundValue, setBoundValue, bindConfig] = Form.useBindingTools(bind, {
+    const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
       value: value?.toString(),
       validationErrorMessages,
       validationMode,

--- a/module/src/components/timeInput/timeInput.component.tsx
+++ b/module/src/components/timeInput/timeInput.component.tsx
@@ -117,7 +117,7 @@ export const TimeInput = React.forwardRef<HTMLInputElement, ITimeInputProps>(
     },
     ref
   ) => {
-    const [selectedTime, setSelectedTime, bindConfig] = Form.useBindingTools(bind, {
+    const [selectedTime, setSelectedTime, bindConfig] = Form.useBindingState(bind, {
       validationErrorMessages,
       validationMode,
       validationErrorIcon: errorIcon,

--- a/module/src/hooks/form/form.hooks.ts
+++ b/module/src/hooks/form/form.hooks.ts
@@ -394,9 +394,9 @@ export function use<TData extends object>(
   return useForm(dataOrBinder, formConfig);
 }
 
-/** The values and callbacks returned from the useBindingTools hook */
+/** The values and callbacks returned from the useBindingState hook */
 
-interface IUseBindingToolsReturnUtils<TData> {
+interface IUseBindingStateReturnUtils<TData> {
   /** Take any value and use the fromData formatter on it */
   getFormattedValueFromData: (val?: TData) => TData | undefined;
 
@@ -419,10 +419,10 @@ interface IUseBindingToolsReturnUtils<TData> {
   shouldShowValidationErrorMessage?: boolean;
 }
 
-type UseBindingToolsReturn<TData> = [TData | undefined, ((newValue: TData) => void) | undefined, IUseBindingToolsReturnUtils<TData>];
+type UseBindingStateReturn<TData> = [TData | undefined, ((newValue: TData) => void) | undefined, IUseBindingStateReturnUtils<TData>];
 
 /** Used as overrides for the bind functionality, for use with component props */
-interface IUseBindingToolsOverrides<TData> {
+interface IUseBindingStateOverrides<TData> {
   /** The current value, will override the value from bind if both are provided */
   value?: TData;
 
@@ -440,11 +440,14 @@ interface IUseBindingToolsOverrides<TData> {
 }
 
 /**
- * An optional hook for internal form component use. Takes a bind and some optional overrides and ensures that onChange and value
- * use the bind's formatters
+ * An optional hook for internal form component use
+ *
+ * Returns a value and setter for the current input's state in a Form.use from a bind
+ *
+ * Refer to internal Armstrong code for Input for a clear example
  */
 
-export function useBindingTools<TData>(bind?: IBindingProps<TData>, overrides?: IUseBindingToolsOverrides<TData>): UseBindingToolsReturn<TData> {
+export function useBindingState<TData>(bind?: IBindingProps<TData>, overrides?: IUseBindingStateOverrides<TData>): UseBindingStateReturn<TData> {
   const value = React.useMemo(
     () => overrides?.value ?? bind?.bindConfig?.format?.fromData?.(bind.value) ?? bind?.value,
     [overrides?.value, bind?.bindConfig?.format?.fromData, bind?.value]
@@ -486,4 +489,14 @@ export function useBindingTools<TData>(bind?: IBindingProps<TData>, overrides?: 
       shouldShowValidationErrorMessage: validationMode === 'message' || validationMode === 'both',
     },
   ];
+}
+
+/** DEPRECATED - useBindingTools has been renamed useBindingState */
+export function useBindingTools<TData>(bind?: IBindingProps<TData>, overrides?: IUseBindingStateOverrides<TData>): UseBindingStateReturn<TData> {
+  React.useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.warn('useBindingTools has been renamed useBindingState - please update this usage of it');
+  }, []);
+
+  return useBindingState<TData>(bind, overrides);
 }

--- a/module/src/hooks/form/formCustomInput.stories.mdx
+++ b/module/src/hooks/form/formCustomInput.stories.mdx
@@ -18,7 +18,7 @@ interface ICustomTextInputProps {
 }
 
 const CustomTextInput: React.FC<ICustomTextInputProps> = (props) => {
-  const [boundValue, boundOnChange, { myValidationErrorMessages }] = Form.useBindingTools(props.bind);
+  const [boundValue, boundOnChange, { myValidationErrorMessages }] = Form.useBindingState(props.bind);
 
   return (
     <>
@@ -30,7 +30,7 @@ const CustomTextInput: React.FC<ICustomTextInputProps> = (props) => {
 };
 ```
 
-There are plenty of advanced tools within the bind prop, and the use of the `useBindingTools` prop is entirely optional, as long as you're careful to implement the features of the form binder within your custom input then you're good to go!
+There are plenty of advanced tools within the bind prop, and the use of the `useBindingState` prop is entirely optional, as long as you're careful to implement the features of the form binder within your custom input then you're good to go!
 
 Here's the full list of tools contained within a `bind` that your custom inputs can interface with:
 


### PR DESCRIPTION
## What's new?

- Renamed useBindingTools to useBindingState
- Still allow useBindingTools, but with clear deprecation notice and JSDoc

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
