### PR TITLE
Feature/move input width to prototyping theme

### DIFF
--- a/module/src/components/autoCompleteInput/autoCompleteInput.basic.scss
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.basic.scss
@@ -1,7 +1,4 @@
 .arm-autocomplete-input {
-  width: 100%;
-  max-width: $arm-input-width;
-
   .arm-dropdown {
     width: 100%;
   }

--- a/module/src/components/autoCompleteInput/autoCompleteInput.prototyping.scss
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.prototyping.scss
@@ -1,0 +1,4 @@
+.arm-autocomplete-input {
+  width: 100%;
+  max-width: $arm-input-width;
+}

--- a/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.basic.scss
+++ b/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.basic.scss
@@ -1,12 +1,5 @@
 .arm-autocomplete-input-multi {
-  width: 100%;
-  max-width: $arm-input-width;
-
   .arm-dropdown {
     width: 100%;
-  }
-
-  .arm-input-wrapper {
-    width: $arm-input-width-large;
   }
 }

--- a/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.prototyping.scss
+++ b/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.prototyping.scss
@@ -1,0 +1,4 @@
+.arm-autocomplete-input-multi .arm-input-wrapper {
+  width: 100%;
+  max-width: $arm-input-width;
+}

--- a/module/src/components/calendarInput/calendarInput.basic.scss
+++ b/module/src/components/calendarInput/calendarInput.basic.scss
@@ -1,7 +1,9 @@
+$arm-calendar-select-min-width: 60px;
+
 .arm-calendar-select {
   margin-right: 0;
   flex: 1;
-  min-width: 57px;
+  min-width: $arm-calendar-select-width;
 
   .arm-dropdown {
     width: 100%;
@@ -26,7 +28,7 @@
 }
 
 .arm-dropdown-content.arm-calendar-input-dropdown-content {
-  width: $arm-calendar-display-width;
+  width: $arm-calendar-select-min-width;
 
   .arm-calendar-display {
     max-width: none;

--- a/module/src/components/calendarInput/calendarInput.basic.scss
+++ b/module/src/components/calendarInput/calendarInput.basic.scss
@@ -1,6 +1,7 @@
 .arm-calendar-select {
   margin-right: 0;
   flex: 1;
+  min-width: 57px;
 
   .arm-dropdown {
     width: 100%;
@@ -33,9 +34,6 @@
 }
 
 .arm-calendar-input {
-  width: 100%;
-  max-width: $arm-input-width;
-
   .arm-dropdown {
     width: 100%;
 

--- a/module/src/components/calendarInput/calendarInput.basic.scss
+++ b/module/src/components/calendarInput/calendarInput.basic.scss
@@ -1,4 +1,4 @@
-$arm-calendar-select-min-width: 60px;
+$arm-calendar-select-width: 57px;
 
 .arm-calendar-select {
   margin-right: 0;
@@ -28,7 +28,7 @@ $arm-calendar-select-min-width: 60px;
 }
 
 .arm-dropdown-content.arm-calendar-input-dropdown-content {
-  width: $arm-calendar-select-min-width;
+  width: $arm-calendar-display-width;
 
   .arm-calendar-display {
     max-width: none;

--- a/module/src/components/calendarInput/calendarInput.component.tsx
+++ b/module/src/components/calendarInput/calendarInput.component.tsx
@@ -350,7 +350,7 @@ export const CalendarInput = React.forwardRef(
                         return (
                           <React.Fragment key={part + index}>
                             <AutoCompleteInput
-                              className="arm-calendar-select"
+                              className="arm-calendar-select arm-calendar-select-day"
                               {...(additionalDayInputProps || {})}
                               placeholder={additionalDayInputProps?.placeholder || 'day'}
                               disabled={disableInputs}
@@ -365,7 +365,7 @@ export const CalendarInput = React.forwardRef(
                         return (
                           <React.Fragment key={part + index}>
                             <AutoCompleteInput
-                              className="arm-calendar-select"
+                              className="arm-calendar-select arm-calendar-select-month"
                               {...(additionalMonthInputProps || {})}
                               placeholder={additionalMonthInputProps?.placeholder || 'month'}
                               disabled={disableInputs}
@@ -380,7 +380,7 @@ export const CalendarInput = React.forwardRef(
                         return (
                           <React.Fragment key={part + index}>
                             <AutoCompleteInput
-                              className="arm-calendar-select"
+                              className="arm-calendar-select arm-calendar-select-year"
                               {...(additionalYearInputProps || {})}
                               placeholder={additionalYearInputProps?.placeholder || 'year'}
                               disabled={disableInputs}

--- a/module/src/components/calendarInput/calendarInput.prototyping.scss
+++ b/module/src/components/calendarInput/calendarInput.prototyping.scss
@@ -1,4 +1,7 @@
 .arm-calendar-input {
+  width: 100%;
+  max-width: $arm-input-width;
+
   .arm-input-wrapper-above,
   .arm-input-wrapper-below {
     max-height: 0;

--- a/module/src/components/inputWrapper/inputWrapper.basic.scss
+++ b/module/src/components/inputWrapper/inputWrapper.basic.scss
@@ -8,9 +8,6 @@
 }
 
 .arm-input-wrapper {
-  max-width: $arm-input-width;
-  width: 100%;
-
   &[data-disabled='true'] {
     pointer-events: none;
     user-select: none;

--- a/module/src/components/inputWrapper/inputWrapper.prototyping.scss
+++ b/module/src/components/inputWrapper/inputWrapper.prototyping.scss
@@ -3,6 +3,8 @@
   border-radius: $spacing-xxsmall;
   border: 1px solid transparent;
   background-color: $white;
+  max-width: $arm-input-width;
+  width: 100%;
 
   &[data-disabled='true'] {
     opacity: 0.5;

--- a/module/src/components/listBox/listBox.basic.scss
+++ b/module/src/components/listBox/listBox.basic.scss
@@ -1,8 +1,3 @@
-.arm-listbox-wrapper {
-  width: 100%;
-  max-width: $arm-input-width;
-}
-
 .arm-input.arm-listbox {
   cursor: pointer;
 }
@@ -25,6 +20,7 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  min-width: 160px;
 
   .placeholder {
     color: $gray-light;

--- a/module/src/components/listBox/listBox.basic.scss
+++ b/module/src/components/listBox/listBox.basic.scss
@@ -1,3 +1,5 @@
+$arm-listbox-min-width: 160px;
+
 .arm-input.arm-listbox {
   cursor: pointer;
 }
@@ -20,7 +22,7 @@
   display: flex;
   align-items: center;
   cursor: pointer;
-  min-width: 160px;
+  min-width: $arm-listbox-min-width;
 
   .placeholder {
     color: $gray-light;

--- a/module/src/components/listBox/listBox.prototyping.scss
+++ b/module/src/components/listBox/listBox.prototyping.scss
@@ -1,0 +1,4 @@
+.arm-listbox-wrapper {
+  width: 100%;
+  max-width: $arm-input-width;
+}

--- a/module/src/components/listBoxMulti/listBoxMulti.basic.scss
+++ b/module/src/components/listBoxMulti/listBoxMulti.basic.scss
@@ -1,8 +1,3 @@
-.arm-listbox-multi-wrapper {
-  width: 100%;
-  max-width: $arm-input-width;
-}
-
 .arm-listbox-multi {
   cursor: pointer;
 
@@ -22,6 +17,7 @@
   display: flex;
   align-items: center;
   margin-right: $spacing-large;
+  min-width: 160px;
 
   .arm-tag {
     margin-right: $spacing-xsmall;

--- a/module/src/components/listBoxMulti/listBoxMulti.basic.scss
+++ b/module/src/components/listBoxMulti/listBoxMulti.basic.scss
@@ -17,7 +17,7 @@
   display: flex;
   align-items: center;
   margin-right: $spacing-large;
-  min-width: 160px;
+  min-width: $arm-listbox-min-width;
 
   .arm-tag {
     margin-right: $spacing-xsmall;

--- a/module/src/components/listBoxMulti/listBoxMulti.prototyping.scss
+++ b/module/src/components/listBoxMulti/listBoxMulti.prototyping.scss
@@ -1,3 +1,8 @@
+.arm-listbox-multi-wrapper {
+  width: 100%;
+  max-width: $arm-input-width;
+}
+
 .arm-listbox-multi-content {
   .placeholder {
     font-size: 0.75rem;

--- a/module/src/components/modal/modal.component.tsx
+++ b/module/src/components/modal/modal.component.tsx
@@ -38,7 +38,7 @@ export interface IModalProps
   /** should darken the background */
   darkenBackground?: boolean;
 
-  /** The amount of time, in ms, to set data-closing true on the dialog before it has closed */
+  /** The amount of time, in ms, to set data-closing true on the dialog before it has closed - can be used to animate out the modal */
   closeTime?: number;
 }
 

--- a/module/src/components/select/select.basic.scss
+++ b/module/src/components/select/select.basic.scss
@@ -31,4 +31,5 @@
   top: 50%;
   transform: translateY(-50%);
   font-size: 0.6rem;
+  pointer-events: none;
 }

--- a/module/src/components/textArea/textArea.basic.scss
+++ b/module/src/components/textArea/textArea.basic.scss
@@ -1,6 +1,4 @@
 .arm-text-area {
-  max-width: $arm-input-width-large;
-
   .arm-input-inner {
     cursor: text;
   }
@@ -8,7 +6,6 @@
 
 .arm-text-area-textarea {
   min-height: $arm-input-height-large;
-  width: 100%;
   appearance: none;
   background-color: transparent;
   resize: none;

--- a/module/src/components/textArea/textArea.prototyping.scss
+++ b/module/src/components/textArea/textArea.prototyping.scss
@@ -1,10 +1,8 @@
 .arm-text-area {
-  textarea {
-    border: 0;
-    padding: $spacing-xsmall 0;
+  max-width: $arm-input-width-large;
+  width: 100%;
 
-    &:focus {
-      border: 0;
-    }
+  textarea {
+    padding: $spacing-xsmall 0;
   }
 }

--- a/module/src/components/timeInput/timeInput.basic.scss
+++ b/module/src/components/timeInput/timeInput.basic.scss
@@ -1,14 +1,6 @@
-$arm-time-input-width: 47px !default;
-
 .arm-time-input {
-  max-width: max-content;
-
   .arm-input {
     margin-right: 0;
-
-    .arm-input-base-input {
-      width: $arm-time-input-width;
-    }
   }
 
   .arm-time-input-between-inputs {

--- a/module/src/components/timeInput/timeInput.prototyping.scss
+++ b/module/src/components/timeInput/timeInput.prototyping.scss
@@ -1,0 +1,15 @@
+$arm-time-input-width: 47px !default;
+
+.arm-time-input {
+  max-width: initial;
+  width: initial;
+
+  .arm-input {
+    width: auto;
+    max-width: initial;
+  }
+
+  .arm-input-base-input {
+    max-width: $arm-time-input-width;
+  }
+}

--- a/module/src/theme/variables.stories.mdx
+++ b/module/src/theme/variables.stories.mdx
@@ -123,6 +123,8 @@ $transition-slow: 0.8s;
 
 ### Sizing
 
+arm-input-width is only used in the prototyping theme - if you're just on basic, you don't need to worry about it
+
 ```css
 $arm-input-width: 320px;
 $arm-input-width-large: 420px;

--- a/module/src/theme/variables.stories.mdx
+++ b/module/src/theme/variables.stories.mdx
@@ -256,6 +256,20 @@ $arm-switch-input-handle: calc(#{$arm-switch-input-height} - #{$arm-switch-input
 $arm-time-input-width: 50px;
 ```
 
+### CalendarInput
+
+```css
+/* the minimum width of a part of the calendar input - default value is wide enough to fit default values */
+$arm-calendar-select-min-width: 60px;
+```
+
+### Listbox
+
+```css
+/* the minimum width of the listbox (as there's no input inside it to manage the size nicely natively) */
+$arm-listbox-min-width: 160px;
+```
+
 ### ToastNotification
 
 ```css


### PR DESCRIPTION
## What's new?

- move max-width on inputs into prototyping theme

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [X] are your changes in Storybook?
- [X] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [X] does _everything_ have jsdoc?
- [X] is everything exported from index.ts?
- [X] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [X] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [X] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
