### PR TITLE
feature/move-modal-centring-to-prototyping (I meant to basic, i named the branch wrong)

### DIFF
--- a/module/src/components/dropdown/dropdown.component.tsx
+++ b/module/src/components/dropdown/dropdown.component.tsx
@@ -248,6 +248,7 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
           closeOnWindowClick={closeOnWindowClick}
           closeOnBackgroundClick={closeOnBackgroundClick}
           data-scrolling={shouldScrollContent}
+          centred={false}
         >
           <AutoResizer onSizeChange={onSizeChange} resizeHorizontal={false}>
             <div className="arm-dropdown-content-inner">{dropdownContent}</div>

--- a/module/src/components/modal/modal.basic.scss
+++ b/module/src/components/modal/modal.basic.scss
@@ -12,6 +12,10 @@
   height: 100vh;
   z-index: 4;
 
+  &[data-centred='true'] {
+    @include flex-centre-content;
+  }
+
   &[data-close-on-background-click='false'] {
     pointer-events: none;
 

--- a/module/src/components/modal/modal.component.tsx
+++ b/module/src/components/modal/modal.component.tsx
@@ -40,6 +40,9 @@ export interface IModalProps
 
   /** The amount of time, in ms, to set data-closing true on the dialog before it has closed - can be used to animate out the modal */
   closeTime?: number;
+
+  /** should centre the modal (adds data-centred="true" attribute) */
+  centred?: boolean;
 }
 
 /**
@@ -70,6 +73,7 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       wrapperClassName,
       disableClose,
       closeTime,
+      centred,
       ...nativeProps
     },
     ref
@@ -134,6 +138,7 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
           data-is-closing={isClosing}
           aria-hidden={isClosing}
           tabIndex={isClosing ? -1 : undefined}
+          data-centred={centred}
         >
           <div role="dialog" aria-modal="true" {...nativeProps} className={ClassNames.concat('arm-modal', className)} ref={internalRef}>
             {children}
@@ -147,4 +152,5 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
 Modal.defaultProps = {
   closeOnBackgroundClick: true,
   closeTime: 300,
+  centred: true,
 };

--- a/module/src/components/modal/modal.prototyping.scss
+++ b/module/src/components/modal/modal.prototyping.scss
@@ -1,7 +1,3 @@
-.arm-modal-wrapper {
-  @include flex-centre-content;
-}
-
 .arm-modal {
   background-color: $white;
   box-shadow: $shadow-xsmall;

--- a/module/src/components/modal/modal.stories.tsx
+++ b/module/src/components/modal/modal.stories.tsx
@@ -28,6 +28,20 @@ export const Default = () => {
   );
 };
 
+export const NotCentred = () => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>open modal</Button>
+
+      <Modal isOpen={open} onOpenChange={setOpen} centred={false}>
+        I'm in a modal
+      </Modal>
+    </>
+  );
+};
+
 export const DarkenBackground = () => {
   const [open, setOpen] = React.useState(false);
 

--- a/module/src/components/sideMenu/sideMenu.component.tsx
+++ b/module/src/components/sideMenu/sideMenu.component.tsx
@@ -4,14 +4,14 @@ import { ClassNames } from '../../utils';
 import { IModalProps } from '..';
 import { Modal } from '../modal';
 
-export interface ISideMenuProps extends Omit<IModalProps, 'darkenBackground'> {
+export interface ISideMenuProps extends Omit<IModalProps, 'darkenBackground' | 'centred'> {
   side?: 'left' | 'right';
 }
 
 /** Extends the Modal component (see docs for modal) with some extra features and styling to work as a slide in sidebar */
 export const SideMenu: React.FC<ISideMenuProps> = ({ className, children, side, ...modalProps }) => {
   return (
-    <Modal data-side={side} className={ClassNames.concat('arm-side-menu', className)} {...modalProps} darkenBackground>
+    <Modal data-side={side} className={ClassNames.concat('arm-side-menu', className)} {...modalProps} darkenBackground centred={false}>
       {children}
     </Modal>
   );

--- a/module/src/components/tooltip/tooltip.component.tsx
+++ b/module/src/components/tooltip/tooltip.component.tsx
@@ -194,6 +194,7 @@ export const Tooltip = React.forwardRef<ITooltipRef, ITooltipProps>(
           data-position={position?.position}
           role="tooltip"
           data-is-text={typeof content === 'string' || typeof content === 'number'}
+          centred={false}
           {...nativeProps}
         >
           <div id={generatedId} className="arm-tooltip-inner" ref={setInnerRef}>


### PR DESCRIPTION
## What's new?

- move centring of modals to basic theme from prototyping theme
- add new centred prop to modals to add above style, on by default

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
