### PR TITLE
Feature/fix fastclick modal bug

### DIFF
--- a/module/.eslintrc.js
+++ b/module/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     ['import/prefer-default-export']: off,
     ['import/no-cycle']: off,
     ['import/extensions']: off,
-    ["import/no-extraneous-dependencies"]: ["error", {"devDependencies":  [ "**/*.stories.tsx"]}],
+    ['import/no-extraneous-dependencies']: ['error', { devDependencies: ['**/*.stories.tsx'] }],
 
     ['no-unused-vars']: off,
     ['no-use-before-define']: off,
@@ -70,7 +70,7 @@ module.exports = {
     ['@typescript-eslint/unbound-method']: off /* allow requiring of assets */,
     ['@typescript-eslint/explicit-module-boundary-types']: off,
     ['@typescript-eslint/no-var-requires']: off,
-    ['@typescript-eslint/no-floating-promises']: error,
+    ['@typescript-eslint/no-floating-promises']: off,
     ['@typescript-eslint/no-namespace']: off,
     ['@typescript-eslint/interface-name-prefix']: off,
     ['@typescript-eslint/explicit-function-return-type']: off,

--- a/module/src/components/dialog/dialog.component.tsx
+++ b/module/src/components/dialog/dialog.component.tsx
@@ -5,6 +5,7 @@ import { ClassNames } from '../../utils/classNames';
 import { Icon, IconSet, IconUtils, IIcon } from '../icon';
 import { IconButton } from '../iconButton';
 import { IModalProps, Modal } from '../modal';
+import { ModalUtils } from '../modal/modal.utils';
 
 export interface IDialogProps extends Omit<IModalProps, 'darkenBackground'> {
   /** the value to render as the title, will have necessary aria tag added */
@@ -34,16 +35,7 @@ export const Dialog = React.forwardRef<HTMLDivElement, IDialogProps>(
 
     const titleId = title && `${id}_label`;
 
-    const close = React.useCallback(async () => {
-      if (!disableClose) {
-        const shouldClose = await onClose?.();
-
-        if (typeof shouldClose === 'boolean' && shouldClose === false) {
-          return;
-        }
-        onOpenChange?.(false);
-      }
-    }, [onOpenChange]);
+    const close = React.useCallback(() => ModalUtils.closeModal({ disableClose, onClose, onOpenChange }), [onOpenChange, disableClose, onClose]);
 
     return (
       <Modal

--- a/module/src/components/dialog/dialog.component.tsx
+++ b/module/src/components/dialog/dialog.component.tsx
@@ -26,17 +26,28 @@ export interface IDialogProps extends Omit<IModalProps, 'darkenBackground'> {
  * see: https://www.w3.org/WAI/GL/wiki/Using_ARIA_role%3Ddialog_to_implement_a_modal_dialog_box
  */
 export const Dialog = React.forwardRef<HTMLDivElement, IDialogProps>(
-  ({ children, className, wrapperClassName, id: htmlId, title, onOpenChange, closeButtonIcon, titleIcon, ...modalProps }, ref) => {
+  (
+    { children, className, wrapperClassName, id: htmlId, title, onOpenChange, closeButtonIcon, titleIcon, onClose, disableClose, ...modalProps },
+    ref
+  ) => {
     const id = useGeneratedId(htmlId);
 
     const titleId = title && `${id}_label`;
 
-    const onClickClose = React.useCallback(() => {
-      onOpenChange?.(false);
+    const onClickClose = React.useCallback(async () => {
+      if (!disableClose) {
+        const shouldClose = await onClose?.();
+
+        if (typeof shouldClose === 'boolean' && shouldClose === false) {
+          return;
+        }
+        onOpenChange?.(false);
+      }
     }, [onOpenChange]);
 
     return (
       <Modal
+        {...modalProps}
         className={ClassNames.concat('arm-dialog', className)}
         wrapperClassName={ClassNames.concat('arm-dialog-wrapper', wrapperClassName)}
         darkenBackground
@@ -44,7 +55,8 @@ export const Dialog = React.forwardRef<HTMLDivElement, IDialogProps>(
         aria-labelledby={titleId}
         onOpenChange={onOpenChange}
         ref={ref}
-        {...modalProps}
+        onClose={onClose}
+        disableClose={disableClose}
       >
         {!!title || !!titleIcon ? (
           <div className="arm-dialog-top">

--- a/module/src/components/dialog/dialog.component.tsx
+++ b/module/src/components/dialog/dialog.component.tsx
@@ -34,7 +34,7 @@ export const Dialog = React.forwardRef<HTMLDivElement, IDialogProps>(
 
     const titleId = title && `${id}_label`;
 
-    const onClickClose = React.useCallback(async () => {
+    const close = React.useCallback(async () => {
       if (!disableClose) {
         const shouldClose = await onClose?.();
 
@@ -68,10 +68,10 @@ export const Dialog = React.forwardRef<HTMLDivElement, IDialogProps>(
               </p>
             )}
 
-            <IconButton className="arm-dialog-close-button" icon={closeButtonIcon!} minimalStyle onClick={onClickClose} />
+            <IconButton className="arm-dialog-close-button" icon={closeButtonIcon!} minimalStyle onClick={close} />
           </div>
         ) : (
-          <IconButton className="arm-dialog-close-button" icon={closeButtonIcon!} minimalStyle onClick={onClickClose} />
+          <IconButton className="arm-dialog-close-button" icon={closeButtonIcon!} minimalStyle onClick={close} />
         )}
         <div className="arm-dialog-inner">{children}</div>
       </Modal>

--- a/module/src/components/dialog/dialog.stories.tsx
+++ b/module/src/components/dialog/dialog.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button } from '../..';
+import { Button, useConfirmationDialog } from '../..';
 import { StoryUtils } from '../../stories/storyUtils';
 import { IconUtils } from '../icon';
 import { Dialog } from './dialog.component';
@@ -66,6 +66,22 @@ export const CustomCloseIcon = () => {
 
       <Dialog isOpen={open} onOpenChange={setOpen} title="I'm the dialog" closeButtonIcon={IconUtils.getIconDefinition('Icomoon', 'station')}>
         I'm in a Dialog
+      </Dialog>
+    </>
+  );
+};
+
+export const HandleClose = () => {
+  const [open, setOpen] = React.useState(false);
+
+  const [openConfirmationDialog] = useConfirmationDialog({ content: 'Are you sure you want to close this dialog?' });
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>open dialog</Button>
+
+      <Dialog isOpen={open} onOpenChange={setOpen} onClose={() => openConfirmationDialog()}>
+        Try and close me
       </Dialog>
     </>
   );

--- a/module/src/components/modal/modal.component.tsx
+++ b/module/src/components/modal/modal.component.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useDelayedDependentSwitch, useEventListener } from '../../hooks';
-import { ClassNames, DOM, Globals } from '../../utils';
+import { ClassNames, Globals } from '../../utils';
 import { IPortalProps, Portal } from '../portal';
 import { useModalLayerElement } from './modal.context';
 
@@ -17,7 +17,8 @@ export interface IModalProps
   /** the modal will close if the user blurs the window */
   closeOnWindowBlur?: boolean;
 
-  /** the modal will close if the user clicks outside of the arm-modal element
+  /**
+   * the modal will close if the user clicks outside of the arm-modal element
    * uses a window click with a stop prop on the modal element, will close all modals with this, not just the last one
    * use closeOnBackgroundClick to ensure that this will only happen when clicking on the
    */
@@ -40,6 +41,9 @@ export interface IModalProps
 
   /** The amount of time, in ms, to set data-closing true on the dialog before it has closed - can be used to animate out the modal */
   closeTime?: number;
+
+  /** Run whenever the modal is closed internally */
+  onClose?: () => void;
 }
 
 /**
@@ -70,28 +74,43 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       wrapperClassName,
       disableClose,
       closeTime,
+      onMouseDown,
+      onClose,
       ...nativeProps
     },
     ref
   ) => {
+    const wrapperRef = useModalLayerElement();
+
     const internalRef = React.useRef<HTMLDivElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!);
 
     const close = React.useCallback(() => {
       if (!disableClose) {
+        onClose?.();
         onOpenChange?.(false);
       }
     }, [onOpenChange, disableClose]);
 
-    /** Close when the user clicks outside of the dropdown */
-    const onWindowClick = React.useCallback(
-      (event: React.MouseEvent<HTMLElement>) => {
-        if (isOpen && closeOnWindowClick && (!internalRef.current || !DOM.clickIsInsideElement(internalRef.current, event))) {
-          close();
-        }
+    /** ensure that clicks initiated inside the modal don't count as clicks on the wrapper if they end outside it (i.e. if a user drags the mouse from inside the modal to the background, it'll still count as a click on that background) */
+    const [mouseDownIsInsideModal, setMouseDownIsInsideModal] = React.useState(false);
+    const onMouseDownModal = React.useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        onMouseDown?.(event);
+        setMouseDownIsInsideModal(true);
       },
-      [isOpen, close, closeOnWindowClick]
+      [onMouseDown]
     );
+
+    /** Close when the user clicks outside of the dropdown */
+    const onWindowClick = React.useCallback(() => {
+      if (isOpen && closeOnWindowClick && !mouseDownIsInsideModal) {
+        close();
+      }
+      setMouseDownIsInsideModal(false);
+    }, [isOpen, close, closeOnWindowClick, mouseDownIsInsideModal]);
+
+    useEventListener('click', onWindowClick, Globals.Document);
 
     /** Close when the user blurs the window */
     const onWindowBlur = React.useCallback(() => {
@@ -100,7 +119,6 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       }
     }, [isOpen, close, closeOnWindowBlur]);
 
-    useEventListener('click', onWindowClick, Globals.Document);
     useEventListener('blur', onWindowBlur, Globals.Window);
 
     /** When the user clicks on the wrapper element, close if closeOnBackgroundClick is true */
@@ -108,18 +126,17 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       (event: React.MouseEvent<HTMLDivElement>) => {
         onClickWrapper?.(event);
 
-        if (closeOnBackgroundClick && (!internalRef.current || !DOM.clickIsInsideElement(internalRef.current, event))) {
+        if (closeOnBackgroundClick && !mouseDownIsInsideModal) {
           close();
         }
       },
-      [onClickWrapper, close, closeOnBackgroundClick]
+      [onClickWrapper, close, closeOnBackgroundClick, mouseDownIsInsideModal]
     );
-
-    const wrapperRef = useModalLayerElement();
 
     /** Have a piece of isClosing state that depends on isOpen */
     const [delayedIsOpen, isClosing] = useDelayedDependentSwitch(isOpen, closeTime!);
 
+    /** render nothing if the modal is closed and isn't currently closing */
     if (!delayedIsOpen && !isClosing) {
       return null;
     }
@@ -128,14 +145,21 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
       <Portal portalTo={portalTo || (!portalToSelector && wrapperRef) || undefined} portalToSelector={portalToSelector}>
         <div
           className={ClassNames.concat('arm-modal-wrapper', wrapperClassName)}
-          onMouseDown={onClickWrapperEvent}
+          onClick={onClickWrapperEvent}
           data-close-on-background-click={!!closeOnBackgroundClick}
           data-darken-background={darkenBackground}
           data-is-closing={isClosing}
           aria-hidden={isClosing}
           tabIndex={isClosing ? -1 : undefined}
         >
-          <div role="dialog" aria-modal="true" {...nativeProps} className={ClassNames.concat('arm-modal', className)} ref={internalRef}>
+          <div
+            role="dialog"
+            aria-modal="true"
+            {...nativeProps}
+            className={ClassNames.concat('arm-modal', className)}
+            ref={internalRef}
+            onMouseDown={onMouseDownModal}
+          >
             {children}
           </div>
         </div>

--- a/module/src/components/modal/modal.component.tsx
+++ b/module/src/components/modal/modal.component.tsx
@@ -4,6 +4,7 @@ import { useDelayedDependentSwitch, useEventListener } from '../../hooks';
 import { ClassNames, Globals } from '../../utils';
 import { IPortalProps, Portal } from '../portal';
 import { useModalLayerElement } from './modal.context';
+import { ModalUtils } from './modal.utils';
 
 export interface IModalProps
   extends Pick<IPortalProps, 'portalToSelector' | 'portalTo'>,
@@ -85,17 +86,7 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
     const internalRef = React.useRef<HTMLDivElement>(null);
     React.useImperativeHandle(ref, () => internalRef.current!);
 
-    const close = React.useCallback(async () => {
-      if (!disableClose) {
-        const shouldClose = await onClose?.();
-
-        if (typeof shouldClose === 'boolean' && shouldClose === false) {
-          return;
-        }
-
-        onOpenChange?.(false);
-      }
-    }, [onOpenChange, disableClose, onClose]);
+    const close = React.useCallback(() => ModalUtils.closeModal({ disableClose, onClose, onOpenChange }), [onOpenChange, disableClose, onClose]);
 
     /** ensure that clicks initiated inside the modal don't count as clicks on the wrapper if they end outside it (i.e. if a user drags the mouse from inside the modal to the background, it'll still count as a click on that background) */
     const [mouseDownIsInsideModal, setMouseDownIsInsideModal] = React.useState(false);

--- a/module/src/components/modal/modal.stories.tsx
+++ b/module/src/components/modal/modal.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { StoryUtils } from '../../stories/storyUtils';
 import { Button } from '../button';
+import { useConfirmationDialog } from '../dialog';
 import { Modal } from './modal.component';
 
 /** metadata */
@@ -71,6 +72,22 @@ export const CloseOnWindowBlur = () => {
 
       <Modal isOpen={open} onOpenChange={setOpen} closeOnBackgroundClick={false} closeOnWindowBlur>
         Click outside the browser window to close
+      </Modal>
+    </>
+  );
+};
+
+export const HandleClose = () => {
+  const [open, setOpen] = React.useState(false);
+
+  const [openConfirmationDialog] = useConfirmationDialog({ content: 'Are you sure you want to close this modal?' });
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>open modal</Button>
+
+      <Modal isOpen={open} onOpenChange={setOpen} onClose={() => openConfirmationDialog()} darkenBackground>
+        Try and close me
       </Modal>
     </>
   );

--- a/module/src/components/modal/modal.utils.ts
+++ b/module/src/components/modal/modal.utils.ts
@@ -1,0 +1,15 @@
+import { IModalProps } from './modal.component';
+
+export namespace ModalUtils {
+  export const closeModal = async ({ disableClose, onClose, onOpenChange }: Pick<IModalProps, 'disableClose' | 'onClose' | 'onOpenChange'>) => {
+    if (!disableClose) {
+      const shouldClose = await onClose?.();
+
+      if (typeof shouldClose === 'boolean' && shouldClose === false) {
+        return;
+      }
+
+      onOpenChange?.(false);
+    }
+  };
+}

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -3969,6 +3969,11 @@
         }
       }
     },
+    "react-fastclick": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-fastclick/-/react-fastclick-3.0.2.tgz",
+      "integrity": "sha1-KZTGAIjNqQsLLL+sS258a8c9ajo="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/playground/package.json
+++ b/playground/package.json
@@ -16,6 +16,7 @@
     "@rocketmakers/api-hooks": "^1.1.5",
     "@rocketmakers/armstrong": "0.0.1-alpha.69",
     "history": "^5.0.0",
+    "react-fastclick": "^3.0.2",
     "react-router-dom": "^5.2.0",
     "sass": "^1.35.2",
     "uuid": "^8.3.2"

--- a/playground/src/shell.tsx
+++ b/playground/src/shell.tsx
@@ -8,8 +8,13 @@ import { SelectExample } from "./views/examples/select";
 import { TimeExample } from "./views/examples/time";
 import { Home } from "./views/home/home";
 import { UserEdit } from "./views/user/user";
+import initReactFastclick from 'react-fastclick';
 
 export const Shell: React.FC = () => {
+  React.useEffect(() => {
+    initReactFastclick();
+  }, []);
+
   return (
     <ModalProvider>
       <div className="shell">

--- a/playground/src/views/examples/dialog.tsx
+++ b/playground/src/views/examples/dialog.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   useDialog,
   useInterval,
+  Modal,
 } from "@rocketmakers/armstrong-edge";
 import * as React from "react";
 
@@ -35,9 +36,17 @@ export const DialogExample: React.FC = () => {
   const [counter, setCounter] = React.useState(0)
   useInterval(() => setCounter(counter+1), 500, { setOnMount: true })
 
+  const [isOpen, setIsOpen ] = React.useState(false)
+
   return (
     <>
       <Button onClick={getThing}>open le dialog</Button>
+      <br/>
+      <Button onClick={()=>setIsOpen(true)}>open le modal</Button>
+
+      <Modal isOpen={isOpen} onOpenChange={setIsOpen} closeTime={0}>
+        HELLO
+      </Modal>
     </>
   );
 };


### PR DESCRIPTION
There was a bug with fastclick where, if a user has fastclick enable, the mousedown event on modal wrappers fires the same frame that the modal is mounted - this means it is immediately closed after being opened if opened with a click

The modal was using mousedown events on the wrapper instead of click events as of [this commit](https://github.com/Rocketmakers/armstrong-edge/commit/d19a4f0a4a9157911a4b488d05e77ed226bf64bc) which was to fix a bug where clicks initiated inside the actual modal counted as clicks on the wrapper if the cursor was dragged out of the modal before the mouse up event. (fun with event bubbling basically)

So I had to revert this back to using clicks to fix fastclick firing the mousedown event, but also preserve that bugfix, which has been done by using a piece of state to track if the click initiated inside the modal and ignoring the call to close if so. 

This has also made the old DOM.clickIsInside method redundant in this case as we don't need to check the original event target due to this piece of state, so that has been removed

## What's new?

- add internal state for modals to keep track of if a click initiated inside the modal and cancelling background clicks if so
- add onClose callback to modals, can return false to stop close, can be async (originally just added for debugging purposes, but figured it was useful)

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
