### PR TITLE
Feature/fix dropdown items dismiss

### DIFF
--- a/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
@@ -30,7 +30,14 @@ export interface IAutoCompleteInputProps<Id extends ArmstrongId>
     Pick<IPortalProps, 'portalToSelector' | 'portalTo'>,
     Pick<
       IDropdownItemsProps,
-      'noItemsText' | 'closeOnScroll' | 'closeOnWindowBlur' | 'closeOnWindowClick' | 'closeOnBackgroundClick' | 'closeOnSelection'
+      | 'noItemsText'
+      | 'closeOnScroll'
+      | 'closeOnWindowBlur'
+      | 'closeOnWindowClick'
+      | 'closeOnBackgroundClick'
+      | 'closeOnSelection'
+      | 'alignment'
+      | 'position'
     > {
   /** The options to render when the input is focused */
   options?: IAutoCompleteInputOption<Id>[];
@@ -100,6 +107,8 @@ export const AutoCompleteInput = React.forwardRef(
       closeOnWindowBlur,
       closeOnWindowClick,
       closeOnSelection,
+      alignment,
+      position,
       ...textInputProps
     }: IAutoCompleteInputProps<Id>,
     ref
@@ -265,6 +274,8 @@ export const AutoCompleteInput = React.forwardRef(
             closeOnWindowClick={closeOnWindowClick}
             closeOnSelection={closeOnSelection}
             stretch
+            alignment={alignment}
+            position={position}
           >
             <TextInput
               {...textInputProps}

--- a/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.component.tsx
@@ -264,6 +264,7 @@ export const AutoCompleteInput = React.forwardRef(
             closeOnWindowBlur={closeOnWindowBlur}
             closeOnWindowClick={closeOnWindowClick}
             closeOnSelection={closeOnSelection}
+            stretch
           >
             <TextInput
               {...textInputProps}

--- a/module/src/components/autoCompleteInput/autoCompleteInput.stories.tsx
+++ b/module/src/components/autoCompleteInput/autoCompleteInput.stories.tsx
@@ -173,3 +173,14 @@ export const AsyncOptions = () => {
     </>
   );
 };
+
+export const Above = () => {
+  const [value, setValue] = React.useState<string>();
+
+  return (
+    <>
+      <AutoCompleteInput value={value} onChange={setValue} options={options} position="above" />
+      <p className="bound-value">bound value: {value}</p>
+    </>
+  );
+};

--- a/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.component.tsx
+++ b/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.component.tsx
@@ -73,6 +73,7 @@ export const AutoCompleteInputMulti = React.forwardRef(
       closeOnWindowBlur,
       closeOnWindowClick,
       closeOnSelection,
+
       ...textInputProps
     }: IAutoCompleteInputMultiProps<Id>,
     ref
@@ -173,7 +174,9 @@ export const AutoCompleteInputMulti = React.forwardRef(
         allowFreeText && textInputInternalValue && !options?.find((option) => getOptionName(option) === textInputInternalValue);
 
       return [
+        // spread in a value that is the currently typed option to allow that to be bound if free text is allowed
         ...(showCurrentlyTypingOption ? [{ content: textInputInternalValue!, id: textInputInternalValue! }] : []),
+        // spread in the current value, if it is not currently in the list of options (i.e. options are remote and current option isn't currently given)
         ...(boundValue || [])
           .map((item) => parseOptionTag(item))
           .filter((item) => {
@@ -182,6 +185,7 @@ export const AutoCompleteInputMulti = React.forwardRef(
             return notAnOption && filterByTextInputValue;
           })
           .map<IDropdownItem>((item) => ({ content: item.name || item.id.toString(), id: item.id })),
+        // spread in given options
         ...filteredOptions.map((option) => ({
           content: option.content || getOptionName(option),
           id: option.id,
@@ -223,6 +227,7 @@ export const AutoCompleteInputMulti = React.forwardRef(
             closeOnScroll={closeOnScroll}
             closeOnWindowBlur={closeOnWindowBlur}
             closeOnWindowClick={closeOnWindowClick}
+            stretch
           >
             <TagInput
               {...textInputProps}

--- a/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.component.tsx
+++ b/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.component.tsx
@@ -30,6 +30,8 @@ export interface IAutoCompleteInputMultiProps<Id extends ArmstrongId>
       | 'closeOnWindowBlur'
       | 'closeOnWindowClick'
       | 'closeOnSelection'
+      | 'alignment'
+      | 'position'
     > {
   /** called when an option is selected  */
   onChange?: (value: Id[]) => void;
@@ -73,7 +75,8 @@ export const AutoCompleteInputMulti = React.forwardRef(
       closeOnWindowBlur,
       closeOnWindowClick,
       closeOnSelection,
-
+      alignment,
+      position,
       ...textInputProps
     }: IAutoCompleteInputMultiProps<Id>,
     ref
@@ -228,6 +231,8 @@ export const AutoCompleteInputMulti = React.forwardRef(
             closeOnWindowBlur={closeOnWindowBlur}
             closeOnWindowClick={closeOnWindowClick}
             stretch
+            alignment={alignment}
+            position={position}
           >
             <TagInput
               {...textInputProps}

--- a/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.stories.tsx
+++ b/module/src/components/autoCompleteInputMulti/autoCompleteInputMulti.stories.tsx
@@ -185,3 +185,23 @@ export const WithCustomClasses = () => {
     </>
   );
 };
+
+export const Above = () => {
+  const [value, setValue] = React.useState([]);
+
+  return (
+    <>
+      <AutoCompleteInputMulti
+        value={value}
+        onChange={setValue}
+        options={[
+          { id: 1, name: 'red' },
+          { id: 2, name: 'blue' },
+          { id: 3, name: 'purple' },
+        ]}
+        position="above"
+      />
+      <p className="bound-value">bound value: {value.join(', ')}</p>
+    </>
+  );
+};

--- a/module/src/components/dropdown/dropdown.basic.scss
+++ b/module/src/components/dropdown/dropdown.basic.scss
@@ -9,6 +9,7 @@ $arm-dropdown-height: 180px !default;
 .arm-modal.arm-dropdown-content {
   position: fixed;
   top: var(--arm-dropdown-top);
+  bottom: var(--arm-dropdown-bottom);
   left: var(--arm-dropdown-left);
   max-width: 100vw;
   user-select: none;

--- a/module/src/components/dropdown/dropdown.basic.scss
+++ b/module/src/components/dropdown/dropdown.basic.scss
@@ -10,7 +10,6 @@ $arm-dropdown-height: 180px !default;
   position: fixed;
   top: var(--arm-dropdown-top);
   left: var(--arm-dropdown-left);
-  min-width: max(#{$arm-dropdown-min-width}, var(--arm-dropdown-width));
   max-width: 100vw;
   user-select: none;
   z-index: 2;
@@ -28,6 +27,10 @@ $arm-dropdown-height: 180px !default;
     .arm-dropdown-content-inner {
       max-height: min(#{$arm-dropdown-height}, 100vh);
     }
+  }
+
+  &[data-stretch='true'] {
+    min-width: max(#{$arm-dropdown-min-width}, var(--arm-dropdown-width));
   }
 }
 

--- a/module/src/components/dropdown/dropdown.component.tsx
+++ b/module/src/components/dropdown/dropdown.component.tsx
@@ -81,6 +81,7 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
       closeOnWindowBlur,
       closeOnWindowClick,
       closeOnBackgroundClick,
+      onClick,
       ...htmlProps
     },
     ref
@@ -180,6 +181,10 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
       [openWhenClickInside, closeWhenClickInside, onOpenChange, onMouseDown, isOpen]
     );
 
+    const onClickEvent = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+      onClick?.(event);
+    }, []);
+
     // open on focus
     const onFocusEvent = React.useCallback(
       (event: React.FocusEvent<HTMLDivElement>) => {
@@ -224,15 +229,17 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
     useEventListener('focus', onWindowFocus);
 
     return (
-      <div
-        {...htmlProps}
-        className={ClassNames.concat('arm-dropdown', className)}
-        onMouseDown={onMouseDownEvent}
-        ref={rootRef}
-        data-is-open={isOpen}
-        onFocus={onFocusEvent}
-      >
-        {children}
+      <>
+        <div
+          {...htmlProps}
+          className={ClassNames.concat('arm-dropdown', className)}
+          onMouseDown={onMouseDownEvent}
+          ref={rootRef}
+          data-is-open={isOpen}
+          onFocus={onFocusEvent}
+        >
+          {children}
+        </div>
 
         <Modal
           portalTo={portalTo}
@@ -254,7 +261,7 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
             <div className="arm-dropdown-content-inner">{dropdownContent}</div>
           </AutoResizer>
         </Modal>
-      </div>
+      </>
     );
   }
 );

--- a/module/src/components/dropdown/dropdown.component.tsx
+++ b/module/src/components/dropdown/dropdown.component.tsx
@@ -17,10 +17,10 @@ export interface IDropdownProps
   /** rendered inside the dropdown */
   dropdownContent: JSX.Element;
 
-  /** CSS className property */
+  /** CSS className property - applied to the element wrapping its children, for the actual dropdown itself see contentClassName and modalHtmlProps */
   className?: string;
 
-  /** CSS className for content wrapper */
+  /** CSS className for the div that wraps the actual dropdown */
   contentClassName?: string;
 
   /** should open when the user clicks on children */
@@ -41,11 +41,14 @@ export interface IDropdownProps
   /** should the height be limited and scrolling be enabled - defaults to true */
   shouldScrollContent?: boolean;
 
-  /** the margin in px around the edge of the innerWindow used to detect whether the dropdown is intersecting the edge - used to reposition it */
+  /** the margin in px around the edge of the innerWindow used to detect whether the dropdown is intersecting the edge, used to reposition it */
   edgeDetectionMargin?: number;
 
-  /** if the user blurs then focuses the browser window while the element is focused, it should reopen */
+  /** if the user blurs then focuses the browser window while the element is still focused, it should reopen - false by default */
   reopenOnWindowFocusWhileFocused?: boolean;
+
+  /** props to spread into the modal's root div */
+  modalHtmlProps?: Omit<React.DetailedHTMLProps<React.BaseHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'>;
 }
 
 export interface IDropdownRef {
@@ -56,7 +59,12 @@ export interface IDropdownRef {
   modalRef: React.RefObject<HTMLDivElement | undefined>;
 }
 
-/** Extends the modal (see component modal docs) but positions the modal below the children of the component */
+/**
+ * Extends the modal (see component modal docs) but positions the modal below the children of the component
+ *
+ * Default html props given to this component are applied to the static div that wraps its children. To supply html props to the modal div
+ * see modalHtmlProps
+ */
 export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<IDropdownProps>>(
   (
     {
@@ -81,7 +89,7 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
       closeOnWindowBlur,
       closeOnWindowClick,
       closeOnBackgroundClick,
-      onClick,
+      modalHtmlProps,
       ...htmlProps
     },
     ref
@@ -180,11 +188,6 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
       },
       [openWhenClickInside, closeWhenClickInside, onOpenChange, onMouseDown, isOpen]
     );
-
-    const onClickEvent = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-      onClick?.(event);
-    }, []);
-
     // open on focus
     const onFocusEvent = React.useCallback(
       (event: React.FocusEvent<HTMLDivElement>) => {
@@ -242,9 +245,10 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
         </div>
 
         <Modal
+          {...modalHtmlProps}
           portalTo={portalTo}
           portalToSelector={portalToSelector}
-          className={ClassNames.concat('arm-dropdown-content', contentClassName)}
+          className={ClassNames.concat('arm-dropdown-content', contentClassName, modalHtmlProps?.className)}
           style={modalStyle}
           ref={setModalRef}
           isOpen={isOpen}

--- a/module/src/components/dropdown/dropdown.component.tsx
+++ b/module/src/components/dropdown/dropdown.component.tsx
@@ -163,8 +163,6 @@ export const Dropdown = React.forwardRef<IDropdownRef, React.PropsWithChildren<I
       }
     }, [rootRect?.top, rootRect?.height, modalSize?.height, windowSize.innerHeight, position]);
 
-    console.log(bottom, rootRect.height, rootRect.bottom);
-
     // get left position of modal from root rect and modal's size
     const left = React.useMemo(() => {
       if (rootRect && modalSize) {

--- a/module/src/components/dropdown/dropdown.stories.tsx
+++ b/module/src/components/dropdown/dropdown.stories.tsx
@@ -26,3 +26,47 @@ export const Default = () => {
     </Dropdown>
   );
 };
+
+export const Stretch = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <Dropdown isOpen={isOpen} onOpenChange={setIsOpen} dropdownContent={<p>I'm in a dropdown</p>} stretch>
+      <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-down4')} minimalStyle>
+        Click on me for dropdown
+      </Button>
+    </Dropdown>
+  );
+};
+
+export const Alignments = () => {
+  const [isOpenLeft, setIsOpenLeft] = React.useState(false);
+  const [isOpenCentre, setIsOpenCentre] = React.useState(false);
+  const [isOpenRight, setIsOpenRight] = React.useState(false);
+
+  return (
+    <div>
+      <Dropdown isOpen={isOpenLeft} onOpenChange={setIsOpenLeft} dropdownContent={<p>I'm in a dropdown</p>} alignment="left">
+        <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-down4')} minimalStyle>
+          Left
+        </Button>
+      </Dropdown>
+
+      <br />
+
+      <Dropdown isOpen={isOpenCentre} onOpenChange={setIsOpenCentre} dropdownContent={<p>I'm in a dropdown</p>} alignment="centre">
+        <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-down4')} minimalStyle>
+          Centre
+        </Button>
+      </Dropdown>
+
+      <br />
+
+      <Dropdown isOpen={isOpenRight} onOpenChange={setIsOpenRight} dropdownContent={<p>I'm in a dropdown</p>} alignment="right">
+        <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-down4')} minimalStyle>
+          Right
+        </Button>
+      </Dropdown>
+    </div>
+  );
+};

--- a/module/src/components/dropdown/dropdown.stories.tsx
+++ b/module/src/components/dropdown/dropdown.stories.tsx
@@ -78,7 +78,7 @@ export const Positions = () => {
   return (
     <div>
       <Dropdown isOpen={isOpenAbove} onOpenChange={setIsOpenAbove} dropdownContent={<p>I'm in a dropdown</p>} position="above">
-        <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-down4')} minimalStyle>
+        <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-up4')} minimalStyle>
           Above
         </Button>
       </Dropdown>

--- a/module/src/components/dropdown/dropdown.stories.tsx
+++ b/module/src/components/dropdown/dropdown.stories.tsx
@@ -70,3 +70,26 @@ export const Alignments = () => {
     </div>
   );
 };
+
+export const Positions = () => {
+  const [isOpenAbove, setIsOpenAbove] = React.useState(false);
+  const [isOpenBelow, setIsOpenBelow] = React.useState(false);
+
+  return (
+    <div>
+      <Dropdown isOpen={isOpenAbove} onOpenChange={setIsOpenAbove} dropdownContent={<p>I'm in a dropdown</p>} position="above">
+        <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-down4')} minimalStyle>
+          Above
+        </Button>
+      </Dropdown>
+
+      <br />
+
+      <Dropdown isOpen={isOpenBelow} onOpenChange={setIsOpenBelow} dropdownContent={<p>I'm in a dropdown</p>} position="below">
+        <Button rightIcon={IconUtils.getIconDefinition('Icomoon', 'arrow-down4')} minimalStyle>
+          Below
+        </Button>
+      </Dropdown>
+    </div>
+  );
+};

--- a/module/src/components/dropdownItems/dropdownItems.component.tsx
+++ b/module/src/components/dropdownItems/dropdownItems.component.tsx
@@ -236,7 +236,7 @@ export const DropdownItems: React.FunctionComponent<IDropdownItemsProps> = ({
     <Dropdown
       {...dropdownProps}
       className={ClassNames.concat('arm-dropdown-items', className)}
-      contentClassName={ClassNames.concat('arm-dropdown-items-content', contentClassName)}
+      contentClassName={ClassNames.concat('arm-dropdown-items-content', contentClassName, dropdownProps.modalHtmlProps?.className)}
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       onKeyDown={onKeyDownEvent}

--- a/module/src/components/listBox/listBox.component.tsx
+++ b/module/src/components/listBox/listBox.component.tsx
@@ -140,6 +140,7 @@ export const ListBox = React.forwardRef(
         closeOnWindowBlur={closeOnWindowBlur}
         closeOnWindowClick={closeOnWindowClick}
         closeOnSelection={closeOnSelection}
+        stretch
       >
         <InputWrapper
           ref={internalRef}

--- a/module/src/components/listBox/listBox.component.tsx
+++ b/module/src/components/listBox/listBox.component.tsx
@@ -19,7 +19,14 @@ export interface IListBoxProps<Id extends ArmstrongId, TSelectData = any>
   extends IInputWrapperProps,
     Pick<
       IDropdownItemsProps,
-      'noItemsText' | 'closeOnScroll' | 'closeOnWindowBlur' | 'closeOnWindowClick' | 'closeOnBackgroundClick' | 'closeOnSelection'
+      | 'noItemsText'
+      | 'closeOnScroll'
+      | 'closeOnWindowBlur'
+      | 'closeOnWindowClick'
+      | 'closeOnBackgroundClick'
+      | 'closeOnSelection'
+      | 'alignment'
+      | 'position'
     > {
   /**  prop for binding to an Armstrong form binder (see forms documentation) */
   bind?: IBindingProps<Id>;
@@ -81,6 +88,8 @@ export const ListBox = React.forwardRef(
       closeOnWindowBlur,
       closeOnWindowClick,
       closeOnSelection,
+      alignment,
+      position,
     }: IListBoxProps<Id, TSelectData>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
@@ -141,6 +150,8 @@ export const ListBox = React.forwardRef(
         closeOnWindowClick={closeOnWindowClick}
         closeOnSelection={closeOnSelection}
         stretch
+        alignment={alignment}
+        position={position}
       >
         <InputWrapper
           ref={internalRef}

--- a/module/src/components/listBox/listBox.stories.tsx
+++ b/module/src/components/listBox/listBox.stories.tsx
@@ -104,3 +104,22 @@ export const WithGroupsAndIcons = () => {
     />
   );
 };
+
+export const Above = () => {
+  const [value, setValue] = React.useState<number>();
+
+  return (
+    <ListBox
+      value={value}
+      placeholder="Please pick something...."
+      onSelectOption={(option) => setValue(option?.id)}
+      options={[
+        { id: 1, name: 'red' },
+        { id: 2, name: 'blue' },
+        { id: 3, name: 'pink' },
+        { id: 4, name: 'brown' },
+      ]}
+      position="above"
+    />
+  );
+};

--- a/module/src/components/listBoxMulti/listBoxMulti.component.tsx
+++ b/module/src/components/listBoxMulti/listBoxMulti.component.tsx
@@ -150,6 +150,7 @@ export const ListBoxMulti = React.forwardRef(
         closeOnWindowBlur={closeOnWindowBlur}
         closeOnWindowClick={closeOnWindowClick}
         closeOnBackgroundClick={closeOnBackgroundClick}
+        stretch
       >
         <InputWrapper
           ref={internalRef}

--- a/module/src/components/listBoxMulti/listBoxMulti.component.tsx
+++ b/module/src/components/listBoxMulti/listBoxMulti.component.tsx
@@ -27,6 +27,8 @@ export interface IListBoxMultiProps<Id extends ArmstrongId, TSelectData = any>
       | 'closeOnWindowClick'
       | 'closeOnBackgroundClick'
       | 'closeOnSelection'
+      | 'alignment'
+      | 'position'
     > {
   /**  prop for binding to an Armstrong form binder (see forms documentation) */
   bind?: IBindingProps<Id[]>;
@@ -78,6 +80,8 @@ export const ListBoxMulti = React.forwardRef(
       closeOnWindowClick,
       closeOnBackgroundClick,
       closeOnSelection,
+      alignment,
+      position,
     }: IListBoxMultiProps<Id, TSelectData>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
@@ -151,6 +155,8 @@ export const ListBoxMulti = React.forwardRef(
         closeOnWindowClick={closeOnWindowClick}
         closeOnBackgroundClick={closeOnBackgroundClick}
         stretch
+        alignment={alignment}
+        position={position}
       >
         <InputWrapper
           ref={internalRef}

--- a/module/src/components/listBoxMulti/listBoxMulti.stories.tsx
+++ b/module/src/components/listBoxMulti/listBoxMulti.stories.tsx
@@ -122,3 +122,22 @@ export const WithGroupsAndIcons = () => {
     />
   );
 };
+
+export const Above = () => {
+  const [value, setValue] = React.useState([]);
+
+  return (
+    <ListBoxMulti
+      value={value}
+      placeholder="Please pick something...."
+      onValueChange={setValue}
+      options={[
+        { id: 'a', name: 'red' },
+        { id: 'b', name: 'blue' },
+        { id: 'c', name: 'pink' },
+        { id: 'd', name: 'brown' },
+      ]}
+      position="above"
+    />
+  );
+};


### PR DESCRIPTION
## What's new?

- Fix dropdown stutter on close when click inside due to click bubbling through 2 listeners and close being fired twice
- Add alignment to dropdowns (left, centre, or right)
- Add position to dropdowns (above or below)

## Breaking change

- this change will stop events from bubbling from a dropdown content to the dropdown component's root dive - this is unlikely to be actually being practically used anywhere, but something to bear in mind

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [X] are your changes in Storybook?
- [X] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [X] does _everything_ have jsdoc?
- [X] is everything exported from index.ts?
- [X] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [X] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [X] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
