### PR TITLE
fix: make useMatchMedia use globals

### DIFF
--- a/module/src/hooks/useMatchMedia.ts
+++ b/module/src/hooks/useMatchMedia.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { Globals } from '../utils/globals';
+
 /** Returns whether the document matches the given media query string */
 export function useMatchMedia(
   /** the media query to match on */
@@ -14,7 +16,7 @@ export function useMatchMedia(
     eventListenerOptions?: boolean | AddEventListenerOptions;
   } = {}
 ): boolean {
-  const [isMatching, setIsMatching] = React.useState(window.matchMedia(query).matches);
+  const [isMatching, setIsMatching] = React.useState(Globals.Window?.matchMedia(query).matches || false);
 
   const onMatchesChangeEvent = React.useCallback(
     (event: MediaQueryListEvent) => {
@@ -25,7 +27,11 @@ export function useMatchMedia(
   );
 
   React.useEffect(() => {
-    const media = window.matchMedia(query);
+    const media = Globals.Window?.matchMedia(query);
+
+    if (!media) {
+      return;
+    }
 
     if (media.matches !== isMatching) {
       setIsMatching(media.matches);


### PR DESCRIPTION
## What's new?

- Make useMatchMedia access window through safer Globals.Window to stop errors in SSR where window is unavailable (i.e. in Gatsby)

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
