### PR TITLE
feature/fix-link-button-not-spreading-props

### DIFF
--- a/module/src/components/button/button.component.tsx
+++ b/module/src/components/button/button.component.tsx
@@ -36,7 +36,7 @@ export type IButtonCoreProps = IIconWrapperProps<IconSet, IconSet> &
     cypressTag?: string;
   };
 
-export type IButtonProps = IButtonCoreProps & ButtonHTMLProps & { to?: never };
+export type IButtonProps = IButtonCoreProps & ButtonHTMLProps;
 
 /** Renders the inside of a button, for use in altering the tag used for the wrapper */
 export const ButtonInner: React.FC<React.PropsWithChildren<IButtonCoreProps>> = ({

--- a/module/src/components/link/link.component.tsx
+++ b/module/src/components/link/link.component.tsx
@@ -4,7 +4,7 @@ import { ClassNames } from '../..';
 import { useArmstrongConfig } from '../config/config.context';
 
 export interface ILinkPropsCore {
-  /** the url to push to history on click - is passed to routingContext.LinkComponent in  */
+  /** the url to push to history on click - is passed to routingContext.LinkComponent  */
   to: string;
   className?: string;
 }

--- a/module/src/components/linkButton/linkButton.component.tsx
+++ b/module/src/components/linkButton/linkButton.component.tsx
@@ -16,12 +16,10 @@ export const LinkButton = React.forwardRef(
     return (
       <>
         <Link
-          rootElementProps={{
-            'data-pending': pending,
-            'data-disabled': disabled || pending,
-            'data-error': shouldShowErrorIcon,
-            ...rootElementProps,
-          }}
+          {...rootElementProps}
+          data-pending={pending}
+          data-disabled={disabled || pending}
+          data-error={shouldShowErrorIcon}
           to={to}
           className={ClassNames.concat(minimalStyle ? 'arm-button-minimal' : 'arm-button', 'arm-link-button', className)}
           ref={ref}

--- a/module/src/components/linkButton/linkButton.component.tsx
+++ b/module/src/components/linkButton/linkButton.component.tsx
@@ -8,15 +8,31 @@ import { ILinkProps, Link } from '../link';
 export type ILinkButtonProps<TLinkProps extends Record<string, any>> = IButtonCoreProps & ILinkProps<TLinkProps>;
 
 export const LinkButton = React.forwardRef(
-  <TLinkProps extends Record<string, any>>(props: React.PropsWithChildren<ILinkButtonProps<TLinkProps>>, ref: any) => {
-    const { className, disabled, minimalStyle, validationErrorMessages, error, errorIcon, pending, to, rootElementProps } = props;
-
+  <TLinkProps extends Record<string, any>>(
+    {
+      className,
+      disabled,
+      minimalStyle,
+      validationErrorMessages,
+      error,
+      errorIcon,
+      pending,
+      to,
+      leftIcon,
+      rightIcon,
+      children,
+      statusPosition,
+      hideIconOnStatus,
+      ...props
+    }: React.PropsWithChildren<ILinkButtonProps<TLinkProps>>,
+    ref: any
+  ) => {
     const shouldShowErrorIcon = !!validationErrorMessages?.length || error;
 
     return (
       <>
         <Link
-          {...rootElementProps}
+          {...props}
           data-pending={pending}
           data-disabled={disabled || pending}
           data-error={shouldShowErrorIcon}
@@ -24,7 +40,9 @@ export const LinkButton = React.forwardRef(
           className={ClassNames.concat(minimalStyle ? 'arm-button-minimal' : 'arm-button', 'arm-link-button', className)}
           ref={ref}
         >
-          <ButtonInner {...props} />
+          <ButtonInner leftIcon={leftIcon} rightIcon={rightIcon} statusPosition={statusPosition} hideIconOnStatus={hideIconOnStatus}>
+            {children}
+          </ButtonInner>
         </Link>
 
         {!!validationErrorMessages?.length && <ValidationErrors validationErrors={validationErrorMessages} icon={errorIcon} />}

--- a/module/src/components/linkButton/linkButton.stories.tsx
+++ b/module/src/components/linkButton/linkButton.stories.tsx
@@ -19,7 +19,7 @@ export const Default = StoryUtils.cloneTemplate(Template, { to: 'https://rocketm
 export const PropsPassedToLink = StoryUtils.cloneTemplate(Template, {
   to: 'https://rocketmakers.com',
   children: 'Click me please',
-  rootElementProps: { target: '_blank' },
+  target: '_blank',
 });
 export const WithIcons = StoryUtils.cloneTemplate(Template, {
   to: 'https://rocketmakers.com',


### PR DESCRIPTION
## What's new?

- Props on a LinkButon now make it to the link element

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [ ] are your changes in Storybook?
- [ ] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
- [ ] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [ ] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [ ] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
