### PR TITLE
fix: side menu component now being exported

### DIFF
--- a/module/src/components/index.ts
+++ b/module/src/components/index.ts
@@ -47,6 +47,7 @@ export * from './rangeInput';
 export * from './rating';
 export * from './scrollToEndListener';
 export * from './select';
+export * from './sideMenu';
 export * from './spinner';
 export * from './status';
 export * from './statusWrapper';

--- a/module/src/components/sideMenu/index.ts
+++ b/module/src/components/sideMenu/index.ts
@@ -1,0 +1,1 @@
+export * from './sideMenu.component';


### PR DESCRIPTION
## What's new?

- Side menu component now being exported

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
