### PR TITLE
fix: allow validationErrorIcon to explicitly have no icon

### DIFF
--- a/module/src/hooks/form/form.hooks.ts
+++ b/module/src/hooks/form/form.hooks.ts
@@ -496,7 +496,7 @@ interface IUseBindingStateReturnUtils<TData> {
   validationMode?: FormValidationMode;
 
   /** The current validation mode for the form */
-  validationErrorIcon?: IIcon<IconSet>;
+  validationErrorIcon?: IIcon<IconSet> | '';
 
   /** Derived from the validation mode */
   shouldShowValidationErrorIcon?: boolean;

--- a/module/src/hooks/form/form.types.ts
+++ b/module/src/hooks/form/form.types.ts
@@ -436,7 +436,7 @@ export interface IFormConfig<TData> {
    * An optional icon to use for validation errors in place of the default.
    * @default warning
    */
-  validationErrorIcon?: IIcon<IconSet>;
+  validationErrorIcon?: IIcon<IconSet> | '';
 
   validators?: ClientValidationConfig<TData>;
 }


### PR DESCRIPTION
## What's new?

My designs have no icon on the validation errors, but it appears there's no provision for this in the armstrong typing, as the config property is optional so there needs to be an explicit opt-out. Therefore:

- allowed empty string to be provided as a validationErrorIcon in Form.IFormConfig

While typescript complains, this compiles and works on my local codebase, without rendering an icon.

## Checklist

- [ ] are your changes in Storybook?
- [ ] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
- [ ] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [ ] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [ ] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
