### PR TITLE
fix: fixed bug in which zero indexed array validation messages don't …

### DIFF
--- a/module/src/hooks/form/form.utils.ts
+++ b/module/src/hooks/form/form.utils.ts
@@ -15,7 +15,7 @@ import { IBindingProps, IValidationError, KeyChain } from './form.types';
 export function validationKeyStringFromKeyChain(keyChain: KeyChain, mode: 'dots' | 'brackets'): string {
   switch (mode) {
     case 'dots':
-      return keyChain.filter((key) => !!key).join('.');
+      return keyChain.filter((key) => key?.toString() !== '').join('.');
     case 'brackets':
       return keyChain.reduce<string>((attrString, key) => {
         if (typeof key === 'string') {


### PR DESCRIPTION


## What's new?

The validation checker was filtering out zero because it's falsy, this was causing a bug in nested array validation

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
