### PR TITLE
Corrects matchmedia example on storybook

### DIFF
--- a/module/src/hooks/hooks.stories.mdx
+++ b/module/src/hooks/hooks.stories.mdx
@@ -286,7 +286,7 @@ Returns whether the document matches the given media query string
 
 ```tsx
 // will return true while the window size is less than 1600px
-const isMatching = useMatchMedia('max-width: 1600px');
+const isMatching = useMatchMedia('(max-width: 1600px)');
 ```
 
 [see here for information on the match media api](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)


### PR DESCRIPTION
## What's new?

- Corrected useMatchMedia hook example to use the right format as the current example doesn't work

## Checklist

- [ x ] are your changes in Storybook?
- [ ] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
- [ ] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [ ] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [ ] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
