### PR TITLE
Confirmation dialog content override

### DIFF
--- a/module/.storybook/preview.tsx
+++ b/module/.storybook/preview.tsx
@@ -2,18 +2,20 @@ import * as React from 'react';
 
 import './showCode';
 
-import { ModalProvider } from '../src/components/modal/modal.context';
+import { ToastProvider, ModalProvider } from '../src';
 // import { addParameters } from '@storybook/react';
 
 export const decorators = [
   (Story) => {
     return (
       <div id="host">
-        <ModalProvider>
-          <div className="story-wrapper">
-            <Story />
-          </div>
-        </ModalProvider>
+        <ToastProvider>
+          <ModalProvider>
+            <div className="story-wrapper">
+              <Story />
+            </div>
+          </ModalProvider>
+        </ToastProvider>
       </div>
     );
   },

--- a/module/src/components/dialog/dialog.hooks.tsx
+++ b/module/src/components/dialog/dialog.hooks.tsx
@@ -27,20 +27,22 @@ export interface IUseConfirmationDialogConfig {
 
 /** Render a confirmation dialog and resolve with a boolean representing the users selection (see useDialog) */
 export const useConfirmationDialog = (config: IUseConfirmationDialogConfig = {}, props?: UseDialogDialogProps) => {
-  return useDialog<boolean>(
-    ({ resolve }) => (
+  return useDialog<boolean, IUseConfirmationDialogConfig | undefined>(({ resolve, argument }) => {
+    const content = argument?.content ?? config.content;
+    const yes = argument?.buttons?.yes ?? config.buttons?.yes;
+    const no = argument?.buttons?.no ?? config.buttons?.no;
+    return (
       <>
-        {!config.content || typeof config.content === 'string' ? <p>{config.content || 'Are you sure?'}</p> : config.content}
+        {!content || typeof content === 'string' ? <p>{content || 'Are you sure?'}</p> : content}
         <div className="arm-confirmation-dialog-buttons">
           <Button type="button" className="arm-confirmation-dialog-no-button" onClick={() => resolve(false)}>
-            {config.buttons?.no || 'No'}
+            {no || 'No'}
           </Button>
           <Button type="button" className="arm-confirmation-dialog-yes-button" onClick={() => resolve(true)}>
-            {config.buttons?.yes || 'Yes'}
+            {yes || 'Yes'}
           </Button>
         </div>
       </>
-    ),
-    props
-  );
+    );
+  }, props);
 };

--- a/module/src/components/dialog/dialog.stories.tsx
+++ b/module/src/components/dialog/dialog.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, useConfirmationDialog } from '../..';
+import { Button, useConfirmationDialog, useDispatchToast } from '../..';
 import { StoryUtils } from '../../stories/storyUtils';
 import { IconUtils } from '../icon';
 import { Dialog } from './dialog.component';
@@ -71,6 +71,25 @@ export const CustomCloseIcon = () => {
   );
 };
 
+export const ConfirmationDialog = () => {
+  const dispatch = useDispatchToast();
+
+  // Dialog config passed into the hook can be overridden on a per-property basis when the open method is called.
+  const [open] = useConfirmationDialog({
+    content: 'As an example, this content will be overridden when the dialog is called',
+    buttons: { yes: 'OK', no: 'Cancel' },
+  });
+
+  const onClick = React.useCallback(async () => {
+    const okToContinue = await open({ content: 'Are you sure you want to do that thing?' });
+    if (okToContinue) {
+      dispatch({ content: 'Thing done successfully', type: 'success' });
+    }
+  }, [open, dispatch]);
+
+  return <Button onClick={onClick}>Do a thing</Button>;
+};
+
 export const HandleClose = () => {
   const [open, setOpen] = React.useState(false);
 
@@ -80,7 +99,13 @@ export const HandleClose = () => {
     <>
       <Button onClick={() => setOpen(true)}>open dialog</Button>
 
-      <Dialog isOpen={open} onOpenChange={setOpen} onClose={() => openConfirmationDialog()}>
+      <Dialog
+        isOpen={open}
+        onOpenChange={setOpen}
+        onClose={() => {
+          void openConfirmationDialog();
+        }}
+      >
         Try and close me
       </Dialog>
     </>


### PR DESCRIPTION
## What's new?

- Allows content for a confirmation dialog to be passed in as an argument. Argument content will override hook level content on a per property basis.
- Added a story for confirmation dialog.
- Fixed a little build error in the handle close dialog story.

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
