### PR TITLE
fix: add fallback to deprecated addListener

### DIFF
--- a/module/src/hooks/useMatchMedia.ts
+++ b/module/src/hooks/useMatchMedia.ts
@@ -41,7 +41,7 @@ export function useMatchMedia(
       media.addEventListener('change', onMatchesChangeEvent, eventListenerOptions);
     } catch (err) {
       try {
-        // Fallback for < IOS 15 which doesnt support addListener
+        // Fallback for < IOS 15 which doesnt support addEventListener
         media.addListener(onMatchesChangeEvent);
       } catch (err1) {
         // eslint-disable-next-line no-console -- Ouput error incase both methods fail

--- a/module/src/hooks/useMatchMedia.ts
+++ b/module/src/hooks/useMatchMedia.ts
@@ -37,7 +37,17 @@ export function useMatchMedia(
       setIsMatching(media.matches);
     }
 
-    media.addEventListener('change', onMatchesChangeEvent, eventListenerOptions);
+    try {
+      media.addEventListener('change', onMatchesChangeEvent, eventListenerOptions);
+    } catch (err) {
+      try {
+        // Fallback for < IOS 15 which doesnt support addListener
+        media.addListener(onMatchesChangeEvent);
+      } catch (err1) {
+        // eslint-disable-next-line no-console -- Ouput error incase both methods fail
+        console.error(err1);
+      }
+    }
 
     return () =>
       media.removeEventListener(


### PR DESCRIPTION
## What's new?

- Added a try catch block on event listener to fallback on older module
- Added another catch to better document any other errors that come from this hook

## Checklist

- [ ] are your changes in Storybook?
- [ ] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
- [ ] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [ ] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [ ] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
