### PR TITLE
fix: range input thumb moves along track on safari 16

### DIFF
--- a/module/src/components/rangeInput/rangeInput.basic.scss
+++ b/module/src/components/rangeInput/rangeInput.basic.scss
@@ -40,20 +40,6 @@ $arm-range-input-track-thickness: 6px !default;
   border: 0;
   cursor: pointer;
 
-  @include range-input-thumb {
-    opacity: 0;
-    background-color: transparent;
-    appearance: none;
-    -webkit-appearance: none;
-  }
-
-  @include range-input-track {
-    opacity: 0;
-    background-color: transparent;
-    appearance: none;
-    -webkit-appearance: none;
-  }
-
   &:active {
     ~ .arm-range-input-handle {
       transform: translate(-50%, -50%) scale(1.1);

--- a/module/src/theme/mixins.scss
+++ b/module/src/theme/mixins.scss
@@ -5,34 +5,6 @@
   content: '';
 }
 
-@mixin range-input-thumb {
-  // an unusual limitation with browser specific selectors means that these all need to be
-  // separate selectors and cannot be combined with commas (like a, b, c {} )
-  &::-webkit-slider-thumb {
-    @content;
-  }
-  &::-moz-range-thumb {
-    @content;
-  }
-  &::-ms-thumb {
-    @content;
-  }
-}
-
-@mixin range-input-track {
-  // an unusual limitation with browser specific selectors means that these all need to be
-  // separate selectors and cannot be combined with commas (like a, b, c {} )
-  &::-webkit-slider-runnable-track {
-    @content;
-  }
-  &::-moz-range-track {
-    @content;
-  }
-  &::-ms-track {
-    @content;
-  }
-}
-
 // layout
 
 @mixin fill {

--- a/module/src/theme/mixins.stories.mdx
+++ b/module/src/theme/mixins.stories.mdx
@@ -35,58 +35,6 @@ Adds the base properties needed to initialise a pseudo-element
 }
 ```
 
-### range-input-thumb
-
-Selects the thumb of a range input
-
-```css
-/* definition */
-@mixin range-input-thumb {
-  &::-webkit-slider-thumb {
-    @content;
-  }
-  &::-moz-range-thumb {
-    @content;
-  }
-  &::-ms-thumb {
-    @content;
-  }
-}
-
-/* use */
-@import '~@rocketmakers/armstrong/dist/imports.scss';
-
-@incude range-input-thumb {
-  ...some stuff;
-}
-```
-
-### range-input-track
-
-Selects the track of a range input
-
-```css
-/* definition */
-@mixin range-input-runnable-track {
-  &::-webkit-slider-track {
-    @content;
-  }
-  &::-moz-range-track {
-    @content;
-  }
-  &::-ms-track {
-    @content;
-  }
-}
-
-/* use */
-@import '~@rocketmakers/armstrong/dist/imports.scss';
-
-@incude range-input-track {
-  ...some stuff;
-}
-```
-
 ## <a name="layout">Layout</a>
 
 ### fill


### PR DESCRIPTION
## What's new?

- Range input's thumb, on safari 16, do not move along track when being dragged. When webkit-appearance none 

### Screen recording before change in a consuming project
https://www.loom.com/share/7b2b1853ea59476b89a4e7fb5c5a989c

### Screen recording after the change
#### All the range inputs visually look the same and stay hidden. 
https://www.loom.com/share/cf719ab1919941ffa34d341f4799e145


## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [ ] are your changes in Storybook?
- [ ] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
- [ ] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [ ] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
