### PR TITLE
Fix/array form validation

### DIFF
--- a/module/src/hooks/form/form.validators.ts
+++ b/module/src/hooks/form/form.validators.ts
@@ -66,6 +66,15 @@ export function validateKeyChainProperty<TData>(
   const { message, validator } = validatorConfig;
   const value = valueByKeyChain(formState, fullKeyChain);
 
+  if (Array.isArray(value)) {
+    value.forEach((val, index) => {
+      if (!validator(val)) {
+        onValidate([...fullKeyChain, index], isValidationMessageBuilder(message) ? message(value) : message);
+      }
+    });
+    return;
+  }
+
   if (!validator(value)) {
     onValidate(fullKeyChain, isValidationMessageBuilder(message) ? message(value) : message);
   }

--- a/module/src/hooks/form/form.validators.ts
+++ b/module/src/hooks/form/form.validators.ts
@@ -67,9 +67,9 @@ export function validateKeyChainProperty<TData>(
   const value = valueByKeyChain(formState, fullKeyChain);
 
   if (Array.isArray(value)) {
-    value.forEach((val, index) => {
-      if (!validator(val)) {
-        onValidate([...fullKeyChain, index], isValidationMessageBuilder(message) ? message(value) : message);
+    value.forEach((itemValue, index) => {
+      if (!validator(itemValue)) {
+        onValidate([...fullKeyChain, index], isValidationMessageBuilder(message) ? message(itemValue) : message);
       }
     });
     return;


### PR DESCRIPTION
When running the client side validators, if the item is an array run the validator against each item in the array instead of the full array