### PR TITLE
fix: - Added generic bindings to number input to support strict mode

### DIFF
--- a/module/src/components/numberInput/numberInput.component.tsx
+++ b/module/src/components/numberInput/numberInput.component.tsx
@@ -1,18 +1,14 @@
 import * as React from 'react';
 
 import { Form } from '../../hooks';
+import { ArmstrongFCExtensions, ArmstrongFCReturn, ArmstrongVFCProps, NullOrUndefined } from '../../types';
 import { ClassNames } from '../../utils/classNames';
 import { IInputProps } from '../input/input.component';
 import { InputWrapper } from '../inputWrapper';
 
-export interface INumberInputProps extends Omit<IInputProps<number>, 'type'> {
-  /** The current value of the input as a number */
-  value?: number;
-}
-
 /** Wrap up a text input with type=num which binds to a number */
-export const NumberInput = React.forwardRef<HTMLInputElement, INumberInputProps>(
-  (
+export const NumberInput = React.forwardRef(
+  <TBind extends NullOrUndefined<number>>(
     {
       bind,
       onChange,
@@ -31,11 +27,11 @@ export const NumberInput = React.forwardRef<HTMLInputElement, INumberInputProps>
       statusPosition,
       onValueChange,
       ...nativeProps
-    },
-    ref
+    }: Omit<IInputProps<TBind>, 'type'>,
+    ref: React.ForwardedRef<HTMLInputElement>
   ) => {
     const [boundValue, setBoundValue, bindConfig] = Form.useBindingState(bind, {
-      value,
+      value: (value !== null && value !== undefined) ? (Number(value.toString()) as TBind) : undefined,
       validationErrorMessages,
       validationMode,
       validationErrorIcon,
@@ -50,8 +46,8 @@ export const NumberInput = React.forwardRef<HTMLInputElement, INumberInputProps>
         // force cast to allow undefined value to be passed up when valueAsNumber is NaN (i.e. if the input is cleared)
         // see: [this ticket](https://rocketmakers.atlassian.net/browse/ARM-187) to make form types play nicer with strict mode
         const valueToSet = (Number.isNaN(currentValue) ? undefined : currentValue ?? undefined) as number;
-        setBoundValue?.(valueToSet);
-        onValueChange?.(valueToSet);
+        setBoundValue?.(valueToSet as TBind);
+        onValueChange?.(valueToSet as TBind);
       },
       [onValueChange, onChange, setBoundValue]
     );
@@ -83,4 +79,5 @@ export const NumberInput = React.forwardRef<HTMLInputElement, INumberInputProps>
       </InputWrapper>
     );
   }
-);
+) as (<TBind extends NullOrUndefined<number>>(props: ArmstrongVFCProps<Omit<IInputProps<TBind>, 'type'>, HTMLInputElement>) => ArmstrongFCReturn) &
+  ArmstrongFCExtensions<Omit<IInputProps<any>, 'type'>>;


### PR DESCRIPTION
## What's new?

- Added generic bindings to number input to support strict mode

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
