### PR TITLE
Feat/arm 262 figma in stories

### DIFF
--- a/module/.storybook/main.ts
+++ b/module/.storybook/main.ts
@@ -1,13 +1,12 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
-  addons: ["@storybook/addon-links", "@storybook/addon-essentials", "@storybook/addon-interactions", "@storybook/addon-a11y", "@storybook/test-runner"],
+  addons: ["@storybook/addon-links", "@storybook/addon-essentials", "@storybook/addon-interactions", "@storybook/addon-a11y", "@storybook/test-runner", 'storybook-addon-designs'],
   framework: {
     name: "@storybook/react-vite",
     options: {}
   },
   features: {
-    interactionsDebugger: true
   },
   docs: {
     autodocs: true

--- a/module/package-lock.json
+++ b/module/package-lock.json
@@ -43,6 +43,7 @@
         "sass": "1.54.9",
         "scss-concat": "0.3.9",
         "storybook": "7.0.0-beta.50",
+        "storybook-addon-designs": "^7.0.0-beta.2",
         "ts-jest": "29.0.5",
         "ts-node": "10.9.1",
         "typescript": "4.8.3",
@@ -2350,6 +2351,28 @@
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
       "dev": true
     },
+    "node_modules/@figspec/components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.1.tgz",
+      "integrity": "sha512-UvnEamPEAMh9HExViqpobWmX25g1+soA9kcJu+It3VerMa7CeVyaIbQydNf1Gys5v/rxJVdTDRgQ7OXW2zAAig==",
+      "dev": true,
+      "dependencies": {
+        "lit": "^2.1.3"
+      }
+    },
+    "node_modules/@figspec/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+      "dev": true,
+      "dependencies": {
+        "@figspec/components": "^1.0.1",
+        "@lit-labs/react": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
@@ -3815,6 +3838,27 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "node_modules/@lit-labs/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==",
+      "dev": true
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz",
+      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==",
+      "dev": true
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
+      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "dev": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "node_modules/@mdx-js/react": {
       "version": "2.3.0",
@@ -7828,6 +7872,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -15984,6 +16034,36 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/lit": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.6.1.tgz",
+      "integrity": "sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==",
+      "dev": true,
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.6.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
+      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "dev": true,
+      "dependencies": {
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.6.1.tgz",
+      "integrity": "sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -18924,6 +19004,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-addon-designs": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-7.0.0-beta.2.tgz",
+      "integrity": "sha512-ljBNmyCJdPTXhiBSfA1S+GBxtMooW2M7nxlt49OoCRH7jcxZOYQdiI8JYQiMF5Ur0MGakbSci0Xm+JzAvcm02g==",
+      "dev": true,
+      "dependencies": {
+        "@figspec/react": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@storybook/addon-docs": "^6.4.0 || ^7.0.0",
+        "@storybook/addons": "^6.4.0 || ^7.0.0",
+        "@storybook/api": "^6.4.0 || ^7.0.0",
+        "@storybook/components": "^6.4.0 || ^7.0.0",
+        "@storybook/theming": "^6.4.0 || ^7.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/stream-shift": {
@@ -22371,6 +22477,25 @@
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
       "dev": true
     },
+    "@figspec/components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.1.tgz",
+      "integrity": "sha512-UvnEamPEAMh9HExViqpobWmX25g1+soA9kcJu+It3VerMa7CeVyaIbQydNf1Gys5v/rxJVdTDRgQ7OXW2zAAig==",
+      "dev": true,
+      "requires": {
+        "lit": "^2.1.3"
+      }
+    },
+    "@figspec/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+      "dev": true,
+      "requires": {
+        "@figspec/components": "^1.0.1",
+        "@lit-labs/react": "^1.0.2"
+      }
+    },
     "@floating-ui/core": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
@@ -23556,6 +23681,27 @@
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "dev": true
+    },
+    "@lit-labs/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==",
+      "dev": true
+    },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz",
+      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw==",
+      "dev": true
+    },
+    "@lit/reactive-element": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
+      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "dev": true,
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "@mdx-js/react": {
       "version": "2.3.0",
@@ -26653,6 +26799,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "@types/unist": {
@@ -33024,6 +33176,36 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "lit": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.6.1.tgz",
+      "integrity": "sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==",
+      "dev": true,
+      "requires": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.6.0"
+      }
+    },
+    "lit-element": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
+      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "dev": true,
+      "requires": {
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.2.0"
+      }
+    },
+    "lit-html": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.6.1.tgz",
+      "integrity": "sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -35282,6 +35464,15 @@
       "dev": true,
       "requires": {
         "@storybook/cli": "7.0.0-beta.50"
+      }
+    },
+    "storybook-addon-designs": {
+      "version": "7.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-7.0.0-beta.2.tgz",
+      "integrity": "sha512-ljBNmyCJdPTXhiBSfA1S+GBxtMooW2M7nxlt49OoCRH7jcxZOYQdiI8JYQiMF5Ur0MGakbSci0Xm+JzAvcm02g==",
+      "dev": true,
+      "requires": {
+        "@figspec/react": "^1.0.0"
       }
     },
     "stream-shift": {

--- a/module/package.json
+++ b/module/package.json
@@ -71,6 +71,7 @@
     "sass": "1.54.9",
     "scss-concat": "0.3.9",
     "storybook": "7.0.0-beta.50",
+    "storybook-addon-designs": "^7.0.0-beta.2",
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.8.3",

--- a/module/src/components/button/button.stories.tsx
+++ b/module/src/components/button/button.stories.tsx
@@ -32,11 +32,17 @@ export const Default: StoryObj<typeof Button> = {
     onClick: action('onClick'),
   },
   play: async ({ args, canvasElement }) => {
-  const canvas = within(canvasElement);
-  expect(canvas.getByRole('button')).toHaveTextContent(args.children as string);
-  await userEvent.click(canvas.getByRole('button'));
-  await waitFor(() => expect(args.onClick).toHaveBeenCalled());
-}
+    const canvas = within(canvasElement);
+    expect(canvas.getByRole('button')).toHaveTextContent(args.children as string);
+    await userEvent.click(canvas.getByRole('button'));
+    await waitFor(() => expect(args.onClick).toHaveBeenCalled());
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/f6yAoBwAQop8YahTF2ASSG/Block-up-design-system?node-id=197%3A3561&t=ccw4zqPQDfhSLCVL-1'
+    }
+  }
 };
 
 export const WithIcons: StoryObj<typeof Button> = {


### PR DESCRIPTION
## What's new?

- Adds the ability to link Figma designs to Storybook stories and see them alongside each other in SB.

## Ticket number(s) in JIRA (if internal)

ARM-262

[board](https://rocketmakers.atlassian.net/jira/software/projects/ARM/boards/154)

## Checklist

- [x] are your changes in Storybook?
- [ ] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
- [ ] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [ ] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [ ] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
