### PR TITLE
Feature/new module input + config context

### DIFF
--- a/module-new/.storybook/preview.tsx
+++ b/module-new/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import { themes } from '@storybook/theming';
 
 import '../src/theme/variables.css';
 import '../src/theme/theme.css';
+import './storybook-theme.css';
 
 export const decorators = [
   Story => {

--- a/module-new/.storybook/storybook-theme.css
+++ b/module-new/.storybook/storybook-theme.css
@@ -1,0 +1,5 @@
+@import "https://fonts.googleapis.com/css2?family=Roboto";
+
+body {
+  font-family: 'Roboto', serif;
+}

--- a/module-new/src/components/button/button.component.tsx
+++ b/module-new/src/components/button/button.component.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { concat } from '../../utils/classNames';
+import { useArmstrongConfig } from '../config';
 import { Spinner } from '../spinner/spinner.component';
 
 import './button.theme.css';
@@ -10,9 +11,9 @@ type ButtonHTMLProps = Omit<
   'ref'
 >;
 
-type ButtonDisplayStyle = 'primary' | 'secondary' | 'outline';
-type ButtonDisplaySize = 'small' | 'medium' | 'large' | 'extra-large';
-type ButtonDisplayStatus = 'normal' | 'positive' | 'negative' | 'warning' | 'info';
+export type ButtonDisplayStyle = 'primary' | 'secondary' | 'outline';
+export type ButtonDisplaySize = 'small' | 'medium' | 'large';
+export type ButtonDisplayStatus = 'normal' | 'positive' | 'negative' | 'warning' | 'info';
 
 export interface IButtonProps extends ButtonHTMLProps {
   /** CSS className property */
@@ -63,6 +64,12 @@ export const Button = React.forwardRef<HTMLButtonElement, React.PropsWithChildre
     ...nativeProps
   } = props;
 
+  const globals = useArmstrongConfig({
+    buttonDisplaySize: displaySize,
+    buttonDisplayStyle: displayStyle,
+    buttonPendingPosition: pendingPosition,
+  });
+
   const spinner = (
     <Spinner className={concat('arm-button-spinner', `arm-button-${pendingPosition}-icon`)} role="status" />
   );
@@ -74,8 +81,8 @@ export const Button = React.forwardRef<HTMLButtonElement, React.PropsWithChildre
       className={concat('arm-button', className)}
       data-pending={pending}
       data-disabled={disabled || pending}
-      data-size={displaySize}
-      data-style={displayStyle}
+      data-size={globals.buttonDisplaySize}
+      data-style={globals.buttonDisplayStyle}
       data-status={displayStatus}
       disabled={disabled || pending}
       tabIndex={disabled ? -1 : nativeProps.tabIndex}
@@ -83,9 +90,9 @@ export const Button = React.forwardRef<HTMLButtonElement, React.PropsWithChildre
       ref={ref}
       {...nativeProps}
     >
-      {pending && pendingPosition === 'left' ? spinner : wrappedLeftIcon}
+      {pending && globals.buttonPendingPosition === 'left' ? spinner : wrappedLeftIcon}
       <span className="arm-button-contents">{children}</span>
-      {pending && pendingPosition === 'right' ? spinner : wrappedRightIcon}
+      {pending && globals.buttonPendingPosition === 'right' ? spinner : wrappedRightIcon}
     </button>
   );
 });

--- a/module-new/src/components/config/config.context.tsx
+++ b/module-new/src/components/config/config.context.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { ImSpinner2 } from 'react-icons/im';
+import { IoIosWarning } from 'react-icons/io';
+
+import { stripNullOrUndefined } from '../../utils/objects';
+import type { ButtonDisplaySize, ButtonDisplayStyle } from '../button';
+import type { InputDisplaySize } from '../input';
+
+/**
+ * Armstrong global config type
+ */
+export interface IArmstrongConfigContext {
+  /** overrides the error messaging and icon display used in the error validation display */
+  validationMode?: 'icon' | 'message' | 'both';
+
+  /** which size variant to use for buttons globally by default */
+  buttonDisplaySize?: ButtonDisplaySize;
+
+  /** which style variant to use for buttons globally by default */
+  buttonDisplayStyle?: ButtonDisplayStyle;
+
+  /** which pending position to use for buttons globally by default */
+  buttonPendingPosition?: 'left' | 'right';
+
+  /** which side of the button to show the spinner/error icon on - defaults to 'right' */
+  inputStatusPosition?: 'left' | 'right';
+
+  /** which size variant to use for inputs globally by default */
+  inputDisplaySize?: InputDisplaySize;
+
+  /** hide the icon on the given side if there is an active status - defaults to true */
+  hideInputErrorIconOnStatus?: boolean;
+
+  /** when pending is true should also disable the input */
+  disableInputOnPending?: boolean;
+
+  /** will scroll the validation errors into view when the length of validationErrors changes */
+  scrollValidationErrorsIntoView?: boolean;
+
+  /** Symbol to use as the required indicator on the label, defaults to "*" */
+  requiredIndicator?: React.ReactNode;
+
+  /** the icon to use for the validation errors */
+  validationErrorIcon?: JSX.Element;
+
+  /** the icon to use for the spinner */
+  spinnerIcon?: JSX.Element;
+}
+
+/**
+ * System level defaults for armstrong global config
+ */
+const systemDefaults: Required<IArmstrongConfigContext> = {
+  validationMode: 'both',
+  buttonDisplaySize: 'medium',
+  buttonDisplayStyle: 'primary',
+  buttonPendingPosition: 'right',
+  inputStatusPosition: 'right',
+  inputDisplaySize: 'medium',
+  hideInputErrorIconOnStatus: true,
+  disableInputOnPending: true,
+  scrollValidationErrorsIntoView: false,
+  requiredIndicator: '*',
+  validationErrorIcon: <IoIosWarning size={24} />,
+  spinnerIcon: <ImSpinner2 />,
+};
+
+const ArmstrongConfigContext = React.createContext<Required<IArmstrongConfigContext>>(systemDefaults);
+
+/**
+ * Configuration for Armstrong
+ * - Allows for certain frequently repeated properties to be set at a global level
+ */
+export const ArmstrongConfigProvider: React.FC<React.PropsWithChildren<IArmstrongConfigContext>> = ({
+  children,
+  ...config
+}) => {
+  return (
+    <ArmstrongConfigContext.Provider value={{ ...systemDefaults, ...stripNullOrUndefined(config) }}>
+      {children}
+    </ArmstrongConfigContext.Provider>
+  );
+};
+
+/**
+ * Used to access settings which can be stored globally as Armstrong config
+ * WARNING: For internal Armstrong use only
+ * @param localOverrides Optional overrides for config properties, these will take precedence over anything set globally.
+ * @returns A config dictionary with a guaranteed entry for every key in priority order: {...system, ...global, ...local}
+ */
+export const useArmstrongConfig = (localOverrides?: IArmstrongConfigContext): Required<IArmstrongConfigContext> => {
+  const config = React.useContext(ArmstrongConfigContext);
+  return { ...config, ...stripNullOrUndefined(localOverrides) };
+};

--- a/module-new/src/components/config/index.ts
+++ b/module-new/src/components/config/index.ts
@@ -1,0 +1,1 @@
+export * from './config.context';

--- a/module-new/src/components/input/index.ts
+++ b/module-new/src/components/input/index.ts
@@ -1,0 +1,1 @@
+export * from './input.component';

--- a/module-new/src/components/input/input.component.tsx
+++ b/module-new/src/components/input/input.component.tsx
@@ -1,0 +1,249 @@
+import * as React from 'react';
+import { HTMLInputTypeAttribute } from 'react';
+
+import { useBindingState } from '../../hooks/form';
+import { IBindingProps } from '../../hooks/form/form.types';
+import { useDebounce } from '../../hooks/useDebounce';
+import { ArmstrongFCExtensions, ArmstrongFCProps, ArmstrongFCReturn, NullOrUndefined } from '../../types';
+import { concat } from '../../utils/classNames';
+import { useArmstrongConfig } from '../config';
+import { IInputWrapperProps, InputWrapper } from '../inputWrapper/inputWrapper.component';
+
+import './input.theme.css';
+
+type NativeInputProps = Omit<
+  React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
+  'value' | 'ref'
+>;
+
+export type InputDisplaySize = 'small' | 'medium' | 'large';
+
+interface IDelayedInputBaseProps<TValue> extends NativeInputProps {
+  /** The time in ms to delay the debounce or throttle effect. */
+  milliseconds: number;
+
+  /** Called when the value changes, takes into account any delay values and other effects. */
+  onValueChange: (value: TValue | undefined) => void;
+
+  /** The current value of the input */
+  value?: TValue;
+}
+
+const DebounceInputBase = React.forwardRef<HTMLInputElement, IDelayedInputBaseProps<string>>(
+  ({ milliseconds, value, onValueChange, onChange, ...nativeProps }, ref) => {
+    const [actualValue, setActualValue] = useDebounce(milliseconds, value, onValueChange);
+
+    const onChangeEvent = React.useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        setActualValue(e.currentTarget.value);
+        onChange?.(e);
+      },
+      [setActualValue, onChange]
+    );
+
+    return <input ref={ref} value={actualValue} onChange={onChangeEvent} {...nativeProps} />;
+  }
+);
+
+DebounceInputBase.displayName = 'DebounceInput';
+
+interface IInputProps<TValue extends NullOrUndefined<string> | NullOrUndefined<number>>
+  extends Omit<NativeInputProps, 'type'>,
+    Omit<IInputWrapperProps, 'onClick' | 'onValueChange'> {
+  /** A class name to apply to the input element */
+  inputClassName?: string;
+
+  /**  prop for binding to an Armstrong form binder (see forms documentation) */
+  bind?: IBindingProps<TValue>;
+
+  /** Called when the value changes, takes into account any delay values and other effects. */
+  onValueChange?: (value?: TValue) => void;
+
+  /** The delay config, used to set throttle and debounce values. */
+  delay?: number;
+
+  /** The current value of the input */
+  value?: TValue;
+
+  /** which size variant to use */
+  displaySize?: InputDisplaySize;
+}
+
+type SupportedStringInputTypes =
+  | 'color'
+  | 'date'
+  | 'datetime-local'
+  | 'email'
+  | 'month'
+  | 'password'
+  | 'search'
+  | 'tel'
+  | 'text'
+  | 'time'
+  | 'url'
+  | 'week';
+
+export interface ITextInputProps<TValue extends NullOrUndefined<string>> extends IInputProps<TValue> {
+  /** The type of input, used to discriminate the bind/value type */
+  type?: Extract<HTMLInputTypeAttribute, SupportedStringInputTypes>;
+}
+
+export interface INumberInputProps<TValue extends NullOrUndefined<number>> extends IInputProps<TValue> {
+  /** The type of input, used to discriminate the bind/value type */
+  type: 'number';
+}
+
+/** A component which wraps up a native input element with some binding logic and some repeated elements (icons and stuff) for components which only contain a single input element. */
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  IInputProps<string | number> & { type?: HTMLInputTypeAttribute }
+>(
+  (
+    {
+      bind,
+      onChange,
+      value,
+      className,
+      leftOverlay,
+      rightOverlay,
+      validationErrorMessages,
+      validationMode,
+      errorIcon: validationErrorIcon,
+      pending,
+      disabled,
+      disableOnPending,
+      statusPosition,
+      hideIconOnStatus,
+      onValueChange,
+      scrollValidationErrorsIntoView,
+      delay,
+      validationErrorsClassName,
+      statusClassName,
+      inputClassName,
+      label,
+      required,
+      requiredIndicator,
+      displaySize,
+      labelClassName,
+      labelId,
+      ...nativeProps
+    },
+    ref
+  ) => {
+    const reactId = React.useId();
+    const id = nativeProps.id ?? reactId;
+
+    const globals = useArmstrongConfig({
+      validationMode,
+      disableInputOnPending: disableOnPending,
+      hideInputErrorIconOnStatus: hideIconOnStatus,
+      inputDisplaySize: displaySize,
+      inputStatusPosition: statusPosition,
+      requiredIndicator,
+      validationErrorIcon,
+      scrollValidationErrorsIntoView,
+    });
+
+    const [boundValue, setBoundValue, bindConfig] = useBindingState(bind, {
+      value: value?.toString(),
+      validationErrorMessages,
+      validationMode: globals.validationMode,
+      validationErrorIcon: globals.validationErrorIcon,
+    });
+
+    const parseValue = React.useCallback(
+      (unparsedValue?: string) => {
+        if (nativeProps.type !== 'number') {
+          return unparsedValue;
+        }
+        if (unparsedValue !== null && unparsedValue !== undefined && unparsedValue !== '') {
+          return parseFloat(unparsedValue);
+        }
+        return undefined;
+      },
+      [nativeProps.type]
+    );
+
+    const onBindValueChange = React.useCallback(
+      (currentValue?: string) => {
+        const parsedValue = parseValue(currentValue);
+        const formattedValue = bind?.bindConfig?.format?.toData?.(parsedValue) || parsedValue;
+        setBoundValue(formattedValue);
+      },
+      [setBoundValue, bind, parseValue]
+    );
+
+    const onChangeEvent = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange?.(event);
+        const currentValue = event.currentTarget.value;
+        onBindValueChange(currentValue);
+        onValueChange?.(parseValue(currentValue));
+      },
+      [onBindValueChange, onChange, onValueChange, parseValue]
+    );
+
+    /** onChange used for throttled inputs */
+    const onValueChangeEvent = React.useCallback(
+      (currentValue?: string) => {
+        onBindValueChange(currentValue);
+        onValueChange?.(parseValue(currentValue));
+      },
+      [onValueChange, onBindValueChange, parseValue]
+    );
+
+    const inputProps: NativeInputProps & { value?: string } = {
+      id,
+      className: concat('arm-input-base-input', inputClassName),
+      /** fallback to an empty string if bind is passed in but bound value is undefined to avoid React warning */
+      value: boundValue?.toString() ?? (bind && ''),
+      disabled,
+    };
+
+    return (
+      <>
+        <InputWrapper
+          data-size={globals.inputDisplaySize}
+          className={concat(className, 'arm-input-base')}
+          statusClassName={concat(statusClassName, 'arm-input-base-status')}
+          validationErrorsClassName={concat(validationErrorsClassName, 'arm-input-base-validation')}
+          leftOverlay={leftOverlay}
+          rightOverlay={rightOverlay}
+          validationErrorMessages={bindConfig.validationErrorMessages}
+          errorIcon={bindConfig.validationErrorIcon}
+          validationMode={bindConfig.validationMode}
+          pending={pending}
+          disabled={disabled}
+          statusPosition={globals.inputStatusPosition}
+          scrollValidationErrorsIntoView={globals.scrollValidationErrorsIntoView}
+          disableOnPending={globals.disableInputOnPending}
+          hideIconOnStatus={globals.hideInputErrorIconOnStatus}
+          label={label}
+          labelId={labelId ?? id}
+          labelClassName={concat(labelClassName, 'arm-input-base-label')}
+          required={required}
+          requiredIndicator={globals.requiredIndicator}
+        >
+          {!!delay && (
+            <DebounceInputBase
+              {...nativeProps}
+              {...inputProps}
+              milliseconds={delay}
+              onChange={onChange}
+              onValueChange={onValueChangeEvent}
+              ref={ref}
+            />
+          )}
+          {!delay && <input {...nativeProps} {...inputProps} onChange={onChangeEvent} ref={ref} />}
+        </InputWrapper>
+      </>
+    );
+  }
+  // type assertion to ensure generic works with RefForwarded component
+  // DO NOT CHANGE TYPE WITHOUT CHANGING THIS, FIND TYPE BY INSPECTING React.forwardRef
+) as (<TStringValue extends NullOrUndefined<string>, TNumberValue extends NullOrUndefined<number>>(
+  props: ArmstrongFCProps<ITextInputProps<TStringValue> | INumberInputProps<TNumberValue>, HTMLInputElement>
+) => ArmstrongFCReturn) &
+  ArmstrongFCExtensions<ITextInputProps<string> | INumberInputProps<number>>;
+
+Input.displayName = 'Input';

--- a/module-new/src/components/input/input.stories.mdx
+++ b/module-new/src/components/input/input.stories.mdx
@@ -1,0 +1,14 @@
+import { ArgTypes, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Input } from './input.component';
+
+<Meta title="Inputs/Input" component={Input} />
+
+# Input
+
+Inputs with options to track errors, pending data and so on.
+
+<Canvas withSource="open">
+  <Story id="inputs-input--default" />
+</Canvas>
+
+<ArgTypes of={Input} />

--- a/module-new/src/components/input/input.stories.tsx
+++ b/module-new/src/components/input/input.stories.tsx
@@ -1,0 +1,156 @@
+import { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import { AiFillThunderbolt } from 'react-icons/ai';
+import { BiSearch } from 'react-icons/bi';
+
+import { useForm } from '../../hooks/form';
+import { Input } from './input.component';
+
+/** metadata */
+
+export default {
+  title: 'Inputs/Input',
+  component: Input,
+  args: {
+    type: 'text',
+  },
+} as Meta<typeof Input>;
+
+/** component template */
+
+const Template: StoryObj<typeof Input> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The type discriminator on Input prevents storybook from spreading pure props on here without a cast
+  render: (props: any) => <Input {...props} />,
+};
+
+/** stories */
+
+export const Default: StoryObj<typeof Input> = {
+  ...Template,
+  args: {
+    type: 'text',
+  },
+};
+
+export const Labelled: StoryObj<typeof Input> = {
+  ...Template,
+  render: () => {
+    return (
+      <div>
+        <h2>Default</h2>
+        <Input label="Name" />
+        <h2>Required</h2>
+        <Input label="Name" required={true} />
+      </div>
+    );
+  },
+};
+
+export const Sizes: StoryObj<typeof Input> = {
+  ...Template,
+  render: () => {
+    return (
+      <div>
+        <h2>Small</h2>
+        <Input label="Name" displaySize="small" required={true} />
+        <h2>Medium (default)</h2>
+        <Input label="Name" required={true} />
+        <h2>Large</h2>
+        <Input label="Name" displaySize="large" required={true} />
+      </div>
+    );
+  },
+};
+
+export const Overlay: StoryObj<typeof Input> = {
+  ...Template,
+  render: () => {
+    return (
+      <div>
+        <h2>Left overlay</h2>
+        <Input leftOverlay={<BiSearch size={22} />} />
+        <h2>Right overlay</h2>
+        <Input rightOverlay="kw/h" />
+        <h2>Both</h2>
+        <Input leftOverlay={<AiFillThunderbolt size={22} />} rightOverlay="kw/h" />
+      </div>
+    );
+  },
+};
+
+export const Pending: StoryObj<typeof Input> = {
+  ...Template,
+  render: () => {
+    return (
+      <div>
+        <h2>Default</h2>
+        <Input pending={true} />
+        <h2>Icon on left</h2>
+        <Input pending={true} statusPosition="left" />
+      </div>
+    );
+  },
+};
+
+export const ValidationError: StoryObj<typeof Input> = {
+  ...Template,
+  render: () => {
+    return (
+      <div>
+        <h2>Validation mode - both</h2>
+        <Input validationMode="both" validationErrorMessages={['This field is required']} />
+        <h2>Validation mode - icon only</h2>
+        <Input validationMode="icon" validationErrorMessages={['This field is required']} />
+        <h2>Validation mode - message only</h2>
+        <Input validationMode="message" validationErrorMessages={['This field is required']} />
+        <h2>Icon on left</h2>
+        <Input validationMode="icon" statusPosition="left" validationErrorMessages={['This field is required']} />
+      </div>
+    );
+  },
+};
+
+export const InputTypes: StoryObj<typeof Input> = {
+  ...Template,
+  render: () => {
+    return (
+      <div>
+        <h2>Number</h2>
+        <Input type="number" />
+        <h2>Password</h2>
+        <Input type="password" />
+        <h2>Email</h2>
+        <Input type="email" />
+      </div>
+    );
+  },
+};
+
+export const Bound: StoryObj<typeof Input> = {
+  ...Template,
+  render: () => {
+    const { formProp, formState } = useForm({ text: '', number: 2, debounce: '' });
+    return (
+      <div>
+        <h2>Bound - text</h2>
+        <Input type="text" bind={formProp('text').bind()} />
+        <ul>
+          <li>Value: {formState?.text}</li>
+          <li>Type: {typeof formState?.text}</li>
+        </ul>
+        <h2>Bound - number</h2>
+        <Input type="number" bind={formProp('number').bind()} />
+        <ul>
+          <li>Value: {formState?.number}</li>
+          <li>Type: {typeof formState?.number}</li>
+        </ul>
+        <h2>Bound - debounced text (200ms)</h2>
+        <Input type="text" bind={formProp('debounce').bind()} delay={200} />
+        <ul>
+          <li>Value: {formState?.debounce}</li>
+          <li>Type: {typeof formState?.debounce}</li>
+        </ul>
+      </div>
+    );
+  },
+};

--- a/module-new/src/components/input/input.theme.css
+++ b/module-new/src/components/input/input.theme.css
@@ -1,0 +1,96 @@
+.arm-input-base .arm-input-inner {
+  width: var(--arm-input-width);
+  min-height: var(--arm-input-height);
+  display: flex;
+  align-items: center;
+  background-color: var(--arm-color-white);
+  border: var(--arm-form-border-thickness) solid var(--arm-color-grey-600);
+  border-radius: var(--arm-form-border-radius);
+  overflow: hidden;
+}
+
+.arm-input-base-input {
+  flex: 1;
+  padding: var(--arm-spacing-small) var(--arm-spacing-medium);
+  border: none;
+  background-color: transparent;
+  outline: none;
+  font-size: inherit;
+}
+
+/** SIZES **/
+
+.arm-input-base[data-size="small"] {
+  font-size: var(--arm-font-size-xsmall);
+}
+
+.arm-input-base[data-size="large"] {
+  font-size: var(--arm-font-size-medium);
+}
+
+.arm-input-base[data-size="small"] .arm-input-base-input {
+  padding-top: var(--arm-spacing-xxsmall);
+  padding-bottom: var(--arm-spacing-xxsmall);
+}
+
+.arm-input-base[data-size="large"] .arm-input-base-input {
+  padding-top: var(--arm-spacing-medium);
+  padding-bottom: var(--arm-spacing-medium);
+}
+
+/** LABEL **/
+
+.arm-input-base-label {
+  display: inline-block;
+  margin-bottom: var(--arm-spacing-xxxsmall);
+  margin-left: var(--arm-spacing-xxxsmall);
+}
+
+.arm-input-base[data-size="small"] .arm-input-base-label {
+  font-size: var(--arm-font-size-xsmall);
+}
+
+.arm-input-base[data-size="large"] .arm-input-base-label {
+  font-size: var(--arm-font-size-medium);
+}
+
+/** OVERLAYS **/
+
+.arm-input-base[data-left-overlay] .arm-input-base-input {
+  padding-left: var(--arm-spacing-small);
+}
+
+.arm-input-base[data-right-overlay] .arm-input-base-input {
+  padding-right: var(--arm-spacing-small);
+}
+
+/** FOCUS **/
+
+.arm-input-base .arm-input-inner:focus-within {
+  box-shadow: 0 0 0 calc(var(--arm-form-border-thickness-highlight) - var(--arm-form-border-thickness)) var(--arm-color-grey-1000);
+}
+
+/** STATUS **/
+
+.arm-input-base-status {
+  display: flex;
+  align-items: center;
+}
+
+.arm-input-base-status[data-position="right"] {
+  padding-right: var(--arm-spacing-small);
+}
+
+.arm-input-base-status[data-position="left"] {
+  padding-left: var(--arm-spacing-small);
+}
+
+/** ERROR **/
+
+.arm-input-base[data-error] .arm-input-inner {
+  border-color: var(--arm-color-negative);
+}
+
+.arm-input-base[data-error] .arm-input-inner:focus-within {
+  box-shadow: 0 0 0 calc(var(--arm-form-border-thickness-highlight) - var(--arm-form-border-thickness)) var(--arm-color-negative);
+}

--- a/module-new/src/components/inputWrapper/index.ts
+++ b/module-new/src/components/inputWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './inputWrapper.component';

--- a/module-new/src/components/inputWrapper/inputWrapper.component.tsx
+++ b/module-new/src/components/inputWrapper/inputWrapper.component.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+
+import { ValidationMessage } from '../../hooks/form';
+import { concat } from '../../utils/classNames';
+import { useArmstrongConfig } from '../config';
+import { Label } from '../label';
+import { IStatusWrapperProps, StatusWrapper } from '../statusWrapper/statusWrapper.component';
+import { ValidationErrors } from '../validationErrors';
+
+import './inputWrapper.theme.css';
+
+export interface IInputWrapperProps extends IStatusWrapperProps {
+  /** array of validation errors to render */
+  validationErrorMessages?: ValidationMessage[];
+
+  /** disable use */
+  disabled?: boolean;
+
+  /** hide the icon on the given side if there is an active status - defaults to true */
+  hideIconOnStatus?: boolean;
+
+  /** when pending is true should also disable the input */
+  disableOnPending?: boolean;
+
+  /** will scroll the validation errors into view when the length of validationErrors changes */
+  scrollValidationErrorsIntoView?: boolean;
+
+  /** Content to show on the left of the input */
+  leftOverlay?: React.ReactNode;
+
+  /** Content to show on the right of the input */
+  rightOverlay?: React.ReactNode;
+
+  /** Class name for the status component */
+  statusClassName?: string;
+
+  /** Class name for the validation errors component */
+  validationErrorsClassName?: string;
+
+  /** Class name for the label component */
+  labelClassName?: string;
+
+  /** Optional ID for the label element */
+  labelId?: string;
+
+  /** Some optional label content */
+  label?: React.ReactNode;
+
+  /** Should the label show a required indicator? */
+  required?: boolean;
+
+  /** Symbol to use as the required indicator on the label, defaults to "*" */
+  requiredIndicator?: React.ReactNode;
+}
+
+/** Wrapper for individual input elements, allowing them to be styled consistently] */
+export const InputWrapper = React.forwardRef<HTMLDivElement, React.PropsWithChildren<IInputWrapperProps>>(
+  (
+    {
+      className,
+      children,
+      leftOverlay,
+      rightOverlay,
+      validationMode,
+      validationErrorMessages,
+      errorIcon,
+      disabled,
+      pending,
+      error,
+      statusPosition,
+      hideIconOnStatus,
+      disableOnPending,
+      scrollValidationErrorsIntoView,
+      statusClassName,
+      validationErrorsClassName,
+      label,
+      required,
+      requiredIndicator,
+      labelClassName,
+      labelId,
+      ...nativeProps
+    },
+    ref
+  ) => {
+    const globals = useArmstrongConfig({
+      validationMode,
+      hideInputErrorIconOnStatus: hideIconOnStatus,
+      disableInputOnPending: disableOnPending,
+      requiredIndicator,
+      scrollValidationErrorsIntoView,
+      inputStatusPosition: statusPosition,
+      validationErrorIcon: errorIcon,
+    });
+
+    const shouldShowValidationErrorsList = globals.validationMode === 'both' || globals.validationMode === 'message';
+    const shouldShowErrorIcon =
+      (!!validationErrorMessages?.length && (globals.validationMode === 'both' || globals.validationMode === 'icon')) ||
+      error;
+
+    const showLeftOverlay =
+      leftOverlay &&
+      (globals.inputStatusPosition !== 'left' ||
+        !globals.hideInputErrorIconOnStatus ||
+        (!pending && !shouldShowErrorIcon));
+
+    const showRightOverlay =
+      rightOverlay &&
+      (globals.inputStatusPosition !== 'right' ||
+        !globals.hideInputErrorIconOnStatus ||
+        (!pending && !shouldShowErrorIcon));
+
+    return (
+      <>
+        <div
+          ref={ref}
+          className={concat('arm-input', 'arm-input-wrapper', className)}
+          data-disabled={disabled || (pending && globals.disableInputOnPending) ? true : undefined}
+          data-error={error || !!validationErrorMessages?.length ? true : undefined}
+          data-left-overlay={
+            showLeftOverlay || (globals.inputStatusPosition === 'left' && (shouldShowErrorIcon || pending))
+              ? true
+              : undefined
+          }
+          data-right-overlay={
+            showRightOverlay || (globals.inputStatusPosition === 'right' && (shouldShowErrorIcon || pending))
+              ? true
+              : undefined
+          }
+          {...nativeProps}
+        >
+          {label && (
+            <Label
+              className={concat('arm-input-base-label', labelClassName)}
+              required={required}
+              requiredIndicator={globals.requiredIndicator}
+              htmlFor={labelId}
+            >
+              {label}
+            </Label>
+          )}
+          <div className="arm-input-inner">
+            <StatusWrapper
+              error={error || !!validationErrorMessages?.length}
+              pending={pending}
+              statusPosition={globals.inputStatusPosition}
+              errorIcon={globals.validationErrorIcon}
+              validationMode={globals.validationMode}
+              className={statusClassName}
+            >
+              <>
+                {showLeftOverlay && <div className="arm-input-overlay arm-input-overlay-left">{leftOverlay}</div>}
+                {children}
+                {showRightOverlay && <div className="arm-input-overlay arm-input-overlay-right">{rightOverlay}</div>}
+              </>
+            </StatusWrapper>
+          </div>
+          {!!validationErrorMessages?.length && shouldShowValidationErrorsList && (
+            <ValidationErrors
+              className={validationErrorsClassName}
+              validationMode={globals.validationMode}
+              validationErrors={validationErrorMessages}
+              scrollIntoView={globals.scrollValidationErrorsIntoView}
+            />
+          )}
+        </div>
+      </>
+    );
+  }
+);
+
+InputWrapper.displayName = 'InputWrapper';

--- a/module-new/src/components/inputWrapper/inputWrapper.theme.css
+++ b/module-new/src/components/inputWrapper/inputWrapper.theme.css
@@ -1,0 +1,12 @@
+.arm-input-overlay-left, .arm-input-overlay-right {
+  display: flex;
+  align-items: center;
+}
+
+.arm-input-overlay-left {
+  padding-left: var(--arm-spacing-small);
+}
+
+.arm-input-overlay-right {
+  padding-right: var(--arm-spacing-small);
+}

--- a/module-new/src/components/label/index.ts
+++ b/module-new/src/components/label/index.ts
@@ -1,0 +1,1 @@
+export * from './label.component';

--- a/module-new/src/components/label/label.component.tsx
+++ b/module-new/src/components/label/label.component.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { LabelHTMLAttributes } from 'react';
+
+import { concat } from '../../utils';
+import { useArmstrongConfig } from '../config';
+
+import './label.theme.css';
+
+export interface ILabelProps extends Omit<LabelHTMLAttributes<HTMLLabelElement>, 'ref'> {
+  /** Should the label show a required indicator? */
+  required?: boolean;
+
+  /** Symbol to use as the required indicator, defaults to "*" */
+  requiredIndicator?: React.ReactNode;
+}
+
+/** Render a status icon which can either be pending or errored */
+export const Label = React.forwardRef<HTMLLabelElement, ILabelProps>(
+  ({ required, className, requiredIndicator, children, ...nativeProps }, ref) => {
+    const globals = useArmstrongConfig({
+      requiredIndicator,
+    });
+    return (
+      <label className={concat('arm-label', className)} ref={ref} {...nativeProps}>
+        {children}
+        {required && <span className="arm-label-required-indicator">&nbsp;{globals.requiredIndicator}</span>}
+      </label>
+    );
+  }
+);
+
+Label.displayName = 'Label';

--- a/module-new/src/components/label/label.theme.css
+++ b/module-new/src/components/label/label.theme.css
@@ -1,0 +1,7 @@
+.arm-label {
+  color: var(--arm-color-grey-1000);
+}
+
+.arm-label-required-indicator {
+  color: var(--arm-color-negative);
+}

--- a/module-new/src/components/spinner/spinner.component.tsx
+++ b/module-new/src/components/spinner/spinner.component.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { ImSpinner2 } from 'react-icons/im';
 
 import { concat } from '../../utils/classNames';
+import { useArmstrongConfig } from '../config';
 
 import './spinner.theme.css';
 
 export interface ISpinnerProps extends React.HTMLProps<HTMLDivElement> {
-  /** icon definition for icon to spin in middle of div, can be overriden using children */
+  /** icon definition for icon to spin in middle of div, can be overridden using children */
   icon?: JSX.Element;
 
   /** should the spinner wrapper fill the container, meaning the icon is centred */
@@ -18,21 +18,23 @@ export interface ISpinnerProps extends React.HTMLProps<HTMLDivElement> {
 
 /** Renders a spinner centred in the div that's being wrapped */
 export const Spinner = React.forwardRef<HTMLDivElement, React.PropsWithChildren<ISpinnerProps>>(
-  ({ children, className, icon, fillContainer, label, ...HTMLProps }, ref) => (
-    <div ref={ref} className={concat('arm-spinner', className)} {...HTMLProps} data-fill-container={fillContainer}>
-      <div className="arm-spinner-inner">{children || icon}</div>
-      {label && (
-        <div className="arm-spinner-label">
-          <span>{label}</span>
-        </div>
-      )}
-    </div>
-  )
+  ({ children, className, icon, fillContainer, label, ...HTMLProps }, ref) => {
+    const { spinnerIcon } = useArmstrongConfig({ spinnerIcon: icon });
+    return (
+      <div ref={ref} className={concat('arm-spinner', className)} {...HTMLProps} data-fill-container={fillContainer}>
+        <div className="arm-spinner-inner">{children || spinnerIcon}</div>
+        {label && (
+          <div className="arm-spinner-label">
+            <span>{label}</span>
+          </div>
+        )}
+      </div>
+    );
+  }
 );
 
 Spinner.displayName = 'Spinner';
 
 Spinner.defaultProps = {
-  icon: <ImSpinner2 />,
   fillContainer: true,
 };

--- a/module-new/src/components/spinner/spinner.stories.mdx
+++ b/module-new/src/components/spinner/spinner.stories.mdx
@@ -1,0 +1,14 @@
+import { ArgTypes, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Spinner } from './spinner.component';
+
+<Meta title="Spinners/Spinner" component={Spinner} />
+
+# Spinner
+
+Loadin spinner with option for custom icons
+
+<Canvas withSource="open">
+  <Story id="spinners-spinner--default" />
+</Canvas>
+
+<ArgTypes of={Spinner} />

--- a/module-new/src/components/spinner/spinner.stories.tsx
+++ b/module-new/src/components/spinner/spinner.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+import { BiMinusCircle } from 'react-icons/bi';
+
+import { Spinner } from './spinner.component';
+
+/** metadata */
+
+export default {
+  title: 'Spinners/Spinner',
+  component: Spinner,
+} as Meta<typeof Spinner>;
+
+/** component template */
+
+const Template: StoryObj<typeof Spinner> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The type discriminator on Spinner prevents storybook from spreading pure props on here without a cast
+  render: (props: any) => <Spinner {...props} />,
+};
+
+/** stories */
+
+export const Default: StoryObj<typeof Spinner> = {
+  ...Template,
+};
+
+export const CustomIcon: StoryObj<typeof Spinner> = {
+  ...Template,
+  args: {
+    icon: <BiMinusCircle />,
+  },
+};
+
+export const Labelled: StoryObj<typeof Spinner> = {
+  ...Template,
+  args: {
+    label: 'Loading...',
+  },
+};

--- a/module-new/src/components/spinner/spinner.theme.css
+++ b/module-new/src/components/spinner/spinner.theme.css
@@ -15,6 +15,5 @@
 
 .arm-spinner-label {
   margin-top: var(--arm-spacing-small);
-  font-size: 0.7rem;
-  display: block;
+  font-size: var(--arm-font-size-xsmall);
 }

--- a/module-new/src/components/status/index.ts
+++ b/module-new/src/components/status/index.ts
@@ -1,0 +1,1 @@
+export * from './status.component';

--- a/module-new/src/components/status/status.component.tsx
+++ b/module-new/src/components/status/status.component.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { concat } from '../../utils/classNames';
+import { useArmstrongConfig } from '../config';
+import { Spinner } from '../spinner';
+
+import './status.theme.css';
+
+export interface IStatusProps {
+  /** show a spinner */
+  pending?: boolean;
+
+  /** show an error state  */
+  error?: boolean;
+
+  /** the icon to use for the error */
+  errorIcon?: JSX.Element;
+
+  /** the icon to use for the spinner */
+  spinnerIcon?: JSX.Element;
+
+  /** an optional CSS className for the rendered status */
+  className?: string;
+}
+
+/** Render a status icon which can either be pending or errored */
+export const Status = React.forwardRef<HTMLDivElement, IStatusProps>(
+  ({ pending, error, errorIcon, spinnerIcon, className, ...rest }, ref) => {
+    const globals = useArmstrongConfig({
+      validationErrorIcon: errorIcon,
+      spinnerIcon,
+    });
+
+    if (!error && !pending) {
+      return null;
+    }
+    return (
+      <div
+        ref={ref}
+        className={concat('arm-status', className)}
+        data-active={!!pending || !!error ? true : undefined}
+        data-error={!!error && !pending ? true : undefined}
+        data-pending={pending ? true : undefined}
+        role="status"
+        {...rest}
+      >
+        {error && !pending && globals.validationErrorIcon}
+        {pending && <Spinner className="arm-status-spinner" fillContainer={false} icon={globals.spinnerIcon} />}
+      </div>
+    );
+  }
+);
+
+Status.displayName = 'Status';

--- a/module-new/src/components/status/status.theme.css
+++ b/module-new/src/components/status/status.theme.css
@@ -1,0 +1,3 @@
+.arm-status[data-error] {
+  color: var(--arm-color-negative);
+}

--- a/module-new/src/components/statusWrapper/index.ts
+++ b/module-new/src/components/statusWrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './statusWrapper.component';

--- a/module-new/src/components/statusWrapper/statusWrapper.component.tsx
+++ b/module-new/src/components/statusWrapper/statusWrapper.component.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+
+import { FormValidationMode } from '../../hooks/form';
+import { useArmstrongConfig } from '../config';
+import { Status } from '../status/status.component';
+
+export interface IStatusWrapperProps {
+  /** which side of the button to show the spinner on - defaults to 'right' */
+  statusPosition?: 'left' | 'right';
+
+  /** show an error state icon on the component (will be true automatically if validationErrorMessages are passed in or errors are in the binder) */
+  error?: boolean;
+
+  /** show a spinner and disable */
+  pending?: boolean;
+
+  /** how to render the validation errors */
+  validationMode?: FormValidationMode;
+
+  /** the icon to use for validation errors */
+  errorIcon?: JSX.Element;
+
+  /** an optional CSS className for the rendered status */
+  className?: string;
+}
+
+export const StatusWrapper: React.FC<React.PropsWithChildren<IStatusWrapperProps>> = ({
+  statusPosition,
+  error,
+  pending,
+  errorIcon,
+  validationMode,
+  children,
+  className,
+}) => {
+  const globals = useArmstrongConfig({
+    validationErrorIcon: errorIcon,
+    validationMode,
+    inputStatusPosition: statusPosition,
+  });
+
+  const shouldShowErrorIcon = (globals.validationMode === 'both' || globals.validationMode === 'icon') && !!error;
+
+  return (
+    <>
+      {globals.inputStatusPosition === 'left' && (
+        <Status
+          className={className}
+          error={shouldShowErrorIcon}
+          pending={pending}
+          errorIcon={globals.validationErrorIcon}
+          data-position="left"
+        />
+      )}
+      {children}
+      {globals.inputStatusPosition === 'right' && (
+        <Status
+          className={className}
+          error={shouldShowErrorIcon}
+          pending={pending}
+          errorIcon={globals.validationErrorIcon}
+          data-position="right"
+        />
+      )}
+    </>
+  );
+};

--- a/module-new/src/components/validationErrors/index.ts
+++ b/module-new/src/components/validationErrors/index.ts
@@ -1,1 +1,2 @@
+export * from './validationErrors.component';
 export * from './validationErrors.hooks';

--- a/module-new/src/components/validationErrors/validationErrors.component.tsx
+++ b/module-new/src/components/validationErrors/validationErrors.component.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+
+import type { ValidationMessage } from '../../hooks/form';
+import { concat } from '../../utils/classNames';
+import { useArmstrongConfig } from '../config';
+
+import './validationErrors.theme.css';
+
+export interface IValidationErrorsProps {
+  /** The errors to render */
+  /** Can be a string or {key, element} key is necessary for animating in new messages   */
+  validationErrors: ValidationMessage[];
+
+  /** CSS className property */
+  className?: string;
+
+  /** will scroll the validation errors into view when the length of validationErrors changes */
+  scrollIntoView?: boolean;
+
+  /** overrides the error messaging and icon display used in the error validation display */
+  validationMode?: 'icon' | 'message' | 'both';
+}
+
+/** Render an array of validation errors as error messages */
+export const ValidationErrors = React.forwardRef<HTMLDivElement, React.PropsWithChildren<IValidationErrorsProps>>(
+  ({ validationErrors, className, scrollIntoView, validationMode }, ref) => {
+    const globals = useArmstrongConfig({
+      validationMode,
+      scrollValidationErrorsIntoView: scrollIntoView,
+    });
+
+    const internalRef = React.useRef<HTMLInputElement>(null);
+    React.useImperativeHandle(ref, () => internalRef.current as HTMLInputElement, [internalRef]);
+
+    React.useEffect(() => {
+      if (validationErrors.length > 0 && globals.scrollValidationErrorsIntoView) {
+        internalRef.current?.scrollIntoView({
+          block: 'center',
+          behavior: 'smooth',
+        });
+      }
+    }, [validationErrors.length, globals.scrollValidationErrorsIntoView]);
+
+    /** If the error is a JSX element use the key on the element or the index */
+    const getKey = React.useCallback((error: ValidationMessage, index: number) => {
+      if (typeof error === 'string') {
+        return error + index;
+      }
+      return error?.key ?? index;
+    }, []);
+
+    const shouldShowErrorMessage = globals.validationMode === 'both' || globals.validationMode === 'message';
+
+    return (
+      <div ref={internalRef} className={concat('arm-validation-errors', className)}>
+        {validationErrors.map((error, i) => (
+          <div className="arm-validation-error-message" key={getKey(error, i)}>
+            {shouldShowErrorMessage && <span>{error}</span>}
+          </div>
+        ))}
+      </div>
+    );
+  }
+);
+
+ValidationErrors.displayName = 'ValidationErrors';

--- a/module-new/src/components/validationErrors/validationErrors.theme.css
+++ b/module-new/src/components/validationErrors/validationErrors.theme.css
@@ -1,0 +1,5 @@
+.arm-validation-error-message {
+  font-size: var(--arm-font-size-xsmall);
+  margin-top: var(--arm-spacing-xxsmall);
+  color: var(--arm-color-negative);
+}

--- a/module-new/src/hooks/form/form.hooks.ts
+++ b/module-new/src/hooks/form/form.hooks.ts
@@ -389,25 +389,27 @@ function useFormBase<TData extends object>(
  * @returns The form state, property accessor, and associated helper methods.
  */
 export function useForm<TData extends object>(
-  initialData: TData | InitialDataFunction<TData>,
+  initialData?: TData | InitialDataFunction<TData>,
   formConfig?: IFormConfig<TData>
 ): HookReturn<TData> {
-  const firstInitialData = React.useRef<TData>(initialDataIsCallback(initialData) ? initialData() : initialData);
+  const firstInitialData = React.useRef<TData | undefined>(
+    initialDataIsCallback(initialData) ? initialData() : initialData
+  );
 
-  const [formState, setFormState] = React.useState<TData>(firstInitialData.current);
+  const [formState, setFormState] = React.useState<TData | undefined>(firstInitialData.current);
 
-  const formStateRef = React.useRef<TData>(firstInitialData.current);
+  const formStateRef = React.useRef<TData | undefined>(firstInitialData.current);
 
   const liveInitialDataDependency = initialDataIsCallback(initialData) ? initialData : contentDependency(initialData);
 
-  const liveInitialData = React.useMemo<TData>(() => {
+  const liveInitialData = React.useMemo<TData | undefined>(() => {
     return initialDataIsCallback(initialData) ? initialData(formStateRef.current) : initialData;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- turnery based dependency
   }, [liveInitialDataDependency]);
 
   const dispatch = React.useCallback<FormDispatcher<TData | undefined>>(
     action => {
-      formStateRef.current = dataReducer(formStateRef.current, action as FormAction<object, unknown>) as TData;
+      formStateRef.current = dataReducer(formStateRef.current ?? {}, action as FormAction<object, unknown>) as TData;
       setFormState(formStateRef.current);
       return formStateRef.current;
     },
@@ -510,7 +512,7 @@ interface IUseBindingStateReturnUtils<TData> {
 
 type UseBindingStateReturn<TData> = [
   TData | undefined,
-  ((newValue: TData | undefined) => void) | undefined,
+  (newValue: TData | undefined) => void,
   IUseBindingStateReturnUtils<TData>
 ];
 
@@ -579,7 +581,7 @@ export function useBindingState<TData>(
 
   return [
     value,
-    overrides?.onChange || bind?.setValue ? onChange : undefined,
+    onChange,
     {
       getFormattedValueFromData,
       getFormattedValueToData,

--- a/module-new/src/hooks/form/form.types.ts
+++ b/module-new/src/hooks/form/form.types.ts
@@ -510,21 +510,6 @@ export interface HookReturn<TData extends object> {
   isValid: boolean;
 }
 
-/**
- * The delay config, used to set throttle and debounce values.
- */
-export interface IDelayInputConfig {
-  /**
-   * Whether to use a debounce or a throttle delay.
-   */
-  mode: 'debounce' | 'throttle';
-
-  /**
-   * The number of milliseconds to delay for.
-   */
-  milliseconds: number;
-}
-
 export interface IAddValidationAction {
   type: 'add-validation';
   errors: IValidationError[];

--- a/module-new/src/index.ts
+++ b/module-new/src/index.ts
@@ -2,5 +2,7 @@ import './theme/variables.css';
 import './theme/theme.css';
 
 export * from './hooks/form';
+export * from './components/input';
 export * from './components/button';
 export * from './components/spinner';
+export * from './components/config';

--- a/module-new/src/types/reactExtensions.ts
+++ b/module-new/src/types/reactExtensions.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
 /** Used for exporting `forwardRef` components that use generics */
-export type ArmstrongFCProps<TProps, TRef> = React.PropsWithChildren<TProps> & React.RefAttributes<TRef | undefined>;
-export type ArmstrongVFCProps<TProps, TRef> = TProps & React.RefAttributes<TRef | undefined>;
+export type ArmstrongFCProps<TProps, TRef> = React.PropsWithoutRef<React.PropsWithChildren<TProps>> &
+  React.RefAttributes<TRef>;
+export type ArmstrongVFCProps<TProps, TRef> = React.PropsWithoutRef<TProps> & React.RefAttributes<TRef>;
 export type ArmstrongFCReturn = ReturnType<React.FC>;
 export type ArmstrongFCExtensions<TDefaultProps> = Pick<
   React.FC<TDefaultProps>,

--- a/module-new/src/utils/objects.ts
+++ b/module-new/src/utils/objects.ts
@@ -48,3 +48,18 @@ export function mergeDeep<TObject>(target: TObject, ...sources: Partial<TObject>
 
   return newTarget;
 }
+
+/**
+ * Removes key/value pairs from dictionary objects where the value is null or undefined
+ * @param object The object to check
+ * @returns A new object with the relevant key/value pairs removed
+ */
+export function stripNullOrUndefined<TObject extends object | undefined>(object: TObject): TObject {
+  if (!object) {
+    return object;
+  }
+  return Object.entries(object).reduce(
+    (finalObject, [key, val]) => ({ ...finalObject, ...(val !== null && val !== undefined ? { [key]: val } : {}) }),
+    {} as TObject
+  );
+}


### PR DESCRIPTION
## What's new?

- Added input control and associated components to module-new folder.
- No need for email/number input components, base input component now discriminates on type attribute.
- Also added global Armstrong config context.
- Includes styling and stories

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
