### PR TITLE
feat: ARM-318 - Added new Radix toast to module-new

### DIFF
--- a/module-new/package-lock.json
+++ b/module-new/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.3",
+        "@radix-ui/react-toast": "^1.1.3",
         "lodash": "^4.17.21",
         "react-icons": "^4.8.0",
         "react-select": "5.5.7"
@@ -4535,6 +4536,22 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
+      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-slot": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
@@ -4690,6 +4707,30 @@
         "react": "^16.8 || ^17.0 || ^18.0"
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.1.3.tgz",
+      "integrity": "sha512-yHFgpxi9wjbfPvpSPdYAzivCqw48eA1ofT8m/WqYOVTxKPdmQMuVKRYPlMmj4C1d6tJdFj/LBa1J4iY3fL4OwQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-collection": "1.0.2",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.3",
+        "@radix-ui/react-portal": "1.0.2",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "@radix-ui/react-use-layout-effect": "1.0.0",
+        "@radix-ui/react-visually-hidden": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
@@ -4734,6 +4775,19 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.2.tgz",
+      "integrity": "sha512-qirnJxtYn73HEk1rXL12/mXnu2rwsNHDID10th2JGtdK25T9wX+mxRmGt7iPSahw512GbZOc0syZX1nLQGoEOg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
     "node_modules/@rocketmakers/eslint": {
@@ -29326,6 +29380,18 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "@radix-ui/react-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
+      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-slot": "1.0.1"
+      }
+    },
     "@radix-ui/react-compose-refs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
@@ -29442,6 +29508,26 @@
         "@radix-ui/react-compose-refs": "1.0.0"
       }
     },
+    "@radix-ui/react-toast": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.1.3.tgz",
+      "integrity": "sha512-yHFgpxi9wjbfPvpSPdYAzivCqw48eA1ofT8m/WqYOVTxKPdmQMuVKRYPlMmj4C1d6tJdFj/LBa1J4iY3fL4OwQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-collection": "1.0.2",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-dismissable-layer": "1.0.3",
+        "@radix-ui/react-portal": "1.0.2",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-controllable-state": "1.0.0",
+        "@radix-ui/react-use-layout-effect": "1.0.0",
+        "@radix-ui/react-visually-hidden": "1.0.2"
+      }
+    },
     "@radix-ui/react-use-callback-ref": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
@@ -29474,6 +29560,15 @@
       "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-visually-hidden": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.2.tgz",
+      "integrity": "sha512-qirnJxtYn73HEk1rXL12/mXnu2rwsNHDID10th2JGtdK25T9wX+mxRmGt7iPSahw512GbZOc0syZX1nLQGoEOg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.2"
       }
     },
     "@rocketmakers/eslint": {

--- a/module-new/package.json
+++ b/module-new/package.json
@@ -86,6 +86,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.3",
+    "@radix-ui/react-toast": "^1.1.3",
     "lodash": "^4.17.21",
     "react-icons": "^4.8.0",
     "react-select": "5.5.7"

--- a/module-new/src/components/config/config.context.tsx
+++ b/module-new/src/components/config/config.context.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { ImCross, ImSpinner2 } from 'react-icons/im';
+import { ImSpinner2 } from 'react-icons/im';
 import { IoIosWarning } from 'react-icons/io';
+import { RiCloseLine } from 'react-icons/ri';
 
 import { stripNullOrUndefined } from '../../utils/objects';
 import type { ButtonDisplaySize, ButtonDisplayStyle } from '../button';
 import type { InputDisplaySize } from '../input';
+import type { ToastPosition } from '../toast';
 
 /**
  * Armstrong global config type
@@ -46,8 +48,20 @@ export interface IArmstrongConfigContext {
   /** the icon to use for the spinner */
   spinnerIcon?: JSX.Element;
 
+  /** the element to portal global overlays to (like toast and modal), defaults to the body element */
+  globalPortalTo?: Element | DocumentFragment;
+
   /** the icon to use for the dialog close button */
   dialogCloseButtonIcon?: JSX.Element | false;
+
+  /** how long ot show toast messages for in ms, defaults to 5000 */
+  toastDuration?: number;
+
+  /** where to position the toast, defaults to "bottom-right" */
+  toastPosition?: ToastPosition;
+
+  /** the icon to use for the dialog close button */
+  toastCloseButtonIcon?: JSX.Element | false;
 }
 
 /**
@@ -66,7 +80,11 @@ const systemDefaults: Required<IArmstrongConfigContext> = {
   requiredIndicator: '*',
   validationErrorIcon: <IoIosWarning size={24} />,
   spinnerIcon: <ImSpinner2 />,
-  dialogCloseButtonIcon: <ImCross />,
+  dialogCloseButtonIcon: <RiCloseLine size={24} />,
+  globalPortalTo: document.body,
+  toastDuration: 5000,
+  toastPosition: 'bottom-right',
+  toastCloseButtonIcon: <RiCloseLine size={18} />,
 };
 
 const ArmstrongConfigContext = React.createContext<Required<IArmstrongConfigContext>>(systemDefaults);

--- a/module-new/src/components/dialog/dialog.component.tsx
+++ b/module-new/src/components/dialog/dialog.component.tsx
@@ -1,5 +1,6 @@
 import * as RadixDialog from '@radix-ui/react-dialog';
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 
 import { useCompareValues } from '../../hooks/useCompareValues';
 import { ArmstrongFCExtensions, ArmstrongFCProps, ArmstrongFCReturn } from '../../types';
@@ -135,7 +136,7 @@ export const Dialog = React.forwardRef(
 
     return (
       <RadixDialog.Root open={!finishAction} onOpenChange={onInnerOpenChange}>
-        <RadixDialog.Portal>
+        {ReactDOM.createPortal(
           <RadixDialog.Overlay className={concat('arm-dialog-overlay', overlayClassName)}>
             <RadixDialog.Content className={concat('arm-dialog', className)} data-has-title={title ? true : undefined}>
               {title && <RadixDialog.Title className="arm-dialog-title">{title}</RadixDialog.Title>}
@@ -147,8 +148,9 @@ export const Dialog = React.forwardRef(
                 <RadixDialog.Close className="arm-dialog-close">{globals.dialogCloseButtonIcon}</RadixDialog.Close>
               )}
             </RadixDialog.Content>
-          </RadixDialog.Overlay>
-        </RadixDialog.Portal>
+          </RadixDialog.Overlay>,
+          globals.globalPortalTo
+        )}
       </RadixDialog.Root>
     );
   }

--- a/module-new/src/components/provider/index.ts
+++ b/module-new/src/components/provider/index.ts
@@ -1,0 +1,1 @@
+export * from './provider.component';

--- a/module-new/src/components/provider/provider.component.tsx
+++ b/module-new/src/components/provider/provider.component.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { ArmstrongConfigProvider, IArmstrongConfigContext } from '../config';
+import { ToastProvider } from '../toast';
+
+/** Props type for the unified armstrong provider */
+export interface IArmstrongProviderProps extends React.PropsWithChildren {
+  /** A dictionary of optional global config, overrides the system defaults */
+  config?: IArmstrongConfigContext;
+}
+
+export const ArmstrongProvider: React.FC<IArmstrongProviderProps> = ({ children, config = {} }) => {
+  return (
+    <ArmstrongConfigProvider {...config}>
+      <ToastProvider>{children}</ToastProvider>
+    </ArmstrongConfigProvider>
+  );
+};

--- a/module-new/src/components/toast/index.ts
+++ b/module-new/src/components/toast/index.ts
@@ -1,0 +1,3 @@
+export * from './toast.component';
+export * from './toast.context';
+export * from './toast.hooks';

--- a/module-new/src/components/toast/toast.component.tsx
+++ b/module-new/src/components/toast/toast.component.tsx
@@ -1,0 +1,39 @@
+import * as RadixToast from '@radix-ui/react-toast';
+import * as React from 'react';
+
+import { concat } from '../../utils';
+import type { IToast, ToastPosition } from './toast.context';
+
+import './toast.theme.css';
+
+export interface IToastProps extends IToast {
+  /** where to position the toast, defaults to "bottom-right" */
+  position: ToastPosition;
+
+  /** the icon to use for the dialog close button */
+  closeButtonIcon: JSX.Element | false;
+}
+
+export const Toast: React.FC<IToastProps> = ({
+  title,
+  description,
+  content,
+  duration,
+  position,
+  closeButtonIcon,
+  hideClose,
+  className,
+}) => {
+  return (
+    <RadixToast.Root className={concat('arm-toast', className)} duration={duration} data-position={position}>
+      {title && <RadixToast.Title className="arm-toast-title">{title}</RadixToast.Title>}
+      {description && <RadixToast.Description className="arm-toast-description">{description}</RadixToast.Description>}
+      {closeButtonIcon !== false && !hideClose && (
+        <RadixToast.Close className="arm-toast-close">{closeButtonIcon}</RadixToast.Close>
+      )}
+      {content}
+    </RadixToast.Root>
+  );
+};
+
+Toast.displayName = 'Toast';

--- a/module-new/src/components/toast/toast.context.tsx
+++ b/module-new/src/components/toast/toast.context.tsx
@@ -1,0 +1,99 @@
+import * as RadixToast from '@radix-ui/react-toast';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { useArmstrongConfig } from '../config';
+import { Toast } from './toast.component';
+
+import './toast.theme.css';
+
+/** Type denoting a toast message */
+export interface IToast {
+  /** optional title for the toast popup (will be displayed above description & content) */
+  title?: string;
+  /** optional text content for the toast popup (will be displayed below title & above content) */
+  description?: string;
+  /** optional JSX content for the toast popup (will be displayed below title & description) */
+  content?: React.ReactNode;
+  /** how long to show the toast in ms for (will default to global setting or failing that 5000) */
+  duration?: number;
+  /** hide the close button entirely? */
+  hideClose?: boolean;
+  /** optional class name to add to the toast element */
+  className?: string;
+}
+
+/** Type denoting the position of a toast message */
+export type ToastPosition = 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left';
+
+/** Types of the global toast context */
+interface IToastContext {
+  /** Adds a new toast message to the global stack */
+  addToast: (newToast: IToast) => void;
+}
+
+/** The default context to initialize with */
+const initialContext: IToastContext = {
+  addToast: () => {
+    throw new Error(
+      "Unable to dispatch toast, are you sure you've added either the <ArmstrongProvider> or <ToastProvider>?"
+    );
+  },
+};
+
+/** The global toast context */
+export const ToastContext = React.createContext<IToastContext>(initialContext);
+
+/** The props for the toast provider */
+interface IToastProviderProps {
+  /** how long ot show toast messages for in ms, defaults to 5000 */
+  duration?: number;
+
+  /** where to position the toast, defaults to "bottom-right" */
+  position?: ToastPosition;
+
+  /** the icon to use for the dialog close button */
+  closeButtonIcon?: JSX.Element | false;
+}
+
+export const ToastProvider: React.FC<React.PropsWithChildren<IToastProviderProps>> = ({
+  children,
+  duration,
+  position,
+  closeButtonIcon,
+}) => {
+  const [toasts, addToast] = React.useReducer<React.Reducer<IToast[], IToast>>(
+    (state, action) => [...state, action],
+    []
+  );
+  const globals = useArmstrongConfig({
+    toastDuration: duration,
+    toastPosition: position,
+    toastCloseButtonIcon: closeButtonIcon,
+  });
+
+  const swipeDirection =
+    globals.toastPosition === 'bottom-left' || globals.toastPosition === 'top-left' ? 'left' : 'right';
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      <RadixToast.Provider swipeDirection={swipeDirection} duration={globals.toastDuration}>
+        {children}
+        {toasts.map((toast, i) => (
+          <Toast
+            key={`${toast.title}-${i}`}
+            {...toast}
+            position={globals.toastPosition}
+            closeButtonIcon={globals.toastCloseButtonIcon}
+          />
+        ))}
+        {ReactDOM.createPortal(
+          <RadixToast.Viewport className="arm-toast-viewport" data-position={globals.toastPosition} />,
+          globals.globalPortalTo
+        )}
+      </RadixToast.Provider>
+    </ToastContext.Provider>
+  );
+};
+
+ToastProvider.displayName = 'ToastProvider';

--- a/module-new/src/components/toast/toast.hooks.ts
+++ b/module-new/src/components/toast/toast.hooks.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { ToastContext } from './toast.context';
+
+/**
+ * Simple hook allowing global toast messages to be dispatched.
+ * WARNING: This hook must be used within either the unified <ArmstrongProvider> or standalone <ToastProvider> to work.
+ * @returns A dispatch method for sending a new global toast message
+ */
+export const useToast = () => {
+  const { addToast } = React.useContext(ToastContext);
+  return addToast;
+};

--- a/module-new/src/components/toast/toast.stories.mdx
+++ b/module-new/src/components/toast/toast.stories.mdx
@@ -1,0 +1,69 @@
+import { ArgTypes, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Toast } from './toast.component';
+
+<Meta title="Modals/Toast" component={Toast} />
+
+# Toast
+
+Toasts are small message modals that can be dispatched globally
+
+## How to use global toast in your app
+
+### Step 1 - Wrap your app in the provider
+
+In order for global toast to work, you must first wrap your app in the unified armstrong provider, like so:
+```tsx
+import { ArmstrongProvider } from '@rocketmakers/armstrong-edge';
+
+export const MyApp: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <ArmstrongProvider>
+      {children}
+    </ArmstrongProvider>
+  )
+}
+```
+NOTE: The unified provider allows you to pass global Armstrong config as well as supports toast messages. If you specifically only want the toast messages, you can use `<ToastProvider>` instead but this is not recommended.
+
+### Step 2 - Use the toast hook to dispatch a toast message
+
+Toast messages can be dispatched from any component within the provider using the toast hook, like so:
+```tsx
+import { useToast, IToast } from '@rocketmakers/armstrong-edge';
+
+export const MyComponent: React.FC = () => {
+  const dispatchToast = useToast();
+
+  const toastMessage: IToast = {
+    title: 'Here is a toast!',
+    description: 'Here is the description for my toast'
+  }
+
+  return (
+    <button onClick={() => dispatchToast(toastMessage)}>
+      Send a toast
+    </button>
+  )
+}
+```
+See it in action here:
+
+<Canvas withSource="closed">
+  <Story id="modals-toast--default" />
+</Canvas>
+
+### Step 3 (optional) - Configure your toast using Armstrong global config
+
+Toast messages come out of the box with a sensible set of default properties, but if you need to change the way toast behaves, you can pass config into the unified Armstrong provider like so:
+```tsx
+import { ArmstrongProvider } from '@rocketmakers/armstrong-edge';
+
+export const MyApp: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <ArmstrongProvider config={{ toastDuration: 10000, toastPosition: "top-right" }}>
+      {children}
+    </ArmstrongProvider>
+  )
+}
+```
+NOTE: These settings can also be passed in as props to the `<ToastProvider>` if you're using that, and `duration` can also be set on a per-toast basis

--- a/module-new/src/components/toast/toast.stories.tsx
+++ b/module-new/src/components/toast/toast.stories.tsx
@@ -1,0 +1,86 @@
+import { Meta, StoryObj } from '@storybook/react';
+import * as React from 'react';
+
+import { Button } from '../button';
+import { ArmstrongProvider } from '../provider';
+import { Toast } from './toast.component';
+import { IToast } from './toast.context';
+import { useToast } from './toast.hooks';
+
+/** metadata */
+
+export default {
+  title: 'Modals/Toast',
+  component: Toast,
+} as Meta<typeof Toast>;
+
+/** component template */
+
+const demoToast: IToast = { title: 'Here is a toast!', description: 'Here is the description for my toast' };
+
+const Template: StoryObj<typeof Toast> = {
+  decorators: [
+    Story => (
+      <ArmstrongProvider>
+        <Story />
+      </ArmstrongProvider>
+    ),
+  ],
+  render: () => {
+    const dispatch = useToast();
+
+    return <Button onClick={() => dispatch(demoToast)}>Send a toast</Button>;
+  },
+};
+
+/** stories */
+
+export const Default: StoryObj<typeof Toast> = {
+  ...Template,
+};
+
+export const TopLeft: StoryObj<typeof Toast> = {
+  ...Template,
+  decorators: [
+    Story => (
+      <ArmstrongProvider config={{ toastPosition: 'top-left' }}>
+        <Story />
+      </ArmstrongProvider>
+    ),
+  ],
+};
+
+export const TopRight: StoryObj<typeof Toast> = {
+  ...Template,
+  decorators: [
+    Story => (
+      <ArmstrongProvider config={{ toastPosition: 'top-right' }}>
+        <Story />
+      </ArmstrongProvider>
+    ),
+  ],
+};
+
+export const BottomLeft: StoryObj<typeof Toast> = {
+  ...Template,
+  decorators: [
+    Story => (
+      <ArmstrongProvider config={{ toastPosition: 'bottom-left' }}>
+        <Story />
+      </ArmstrongProvider>
+    ),
+  ],
+};
+
+export const CustomContent: StoryObj<typeof Toast> = {
+  ...Template,
+  render: () => {
+    const dispatch = useToast();
+
+    return (
+      <Button onClick={() => dispatch({ title: 'Toast with a button!', content: <Button>Custom button</Button> })}>
+        Send a toast
+      </Button>
+    );
+  },
+};

--- a/module-new/src/components/toast/toast.theme.css
+++ b/module-new/src/components/toast/toast.theme.css
@@ -1,0 +1,154 @@
+/** OVERLAY **/
+
+.arm-toast-viewport {
+  --arm-toast-viewport-padding: var(--arm-spacing-xlarge);
+
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  padding: var(--arm-toast-viewport-padding);
+  gap: var(--arm-spacing-xsmall);
+  width: var(--arm-toast-width, 390px);
+  max-width: var(--arm-toast-max-width, 100vw);
+  margin: 0;
+  list-style: none;
+  z-index: var(--arm-toast-z-index, 2);
+  outline: none;
+}
+
+/** POSITIONS **/
+
+.arm-toast-viewport[data-position="top-left"] {
+  top: 0;
+  left: 0;
+}
+
+.arm-toast-viewport[data-position="top-right"] {
+  top: 0;
+  right: 0;
+}
+
+.arm-toast-viewport[data-position="bottom-left"] {
+  bottom: 0;
+  left: 0;
+}
+
+.arm-toast-viewport[data-position="bottom-right"] {
+  bottom: 0;
+  right: 0;
+}
+
+/** TOAST ITEM **/
+
+.arm-toast {
+  position: relative;
+  background-color: var(--arm-color-white);
+  border: 1px solid var(--arm-color-grey-100);
+  border-radius: var(--arm-toast-border-radius, var(--arm-button-border-radius));
+  box-shadow: var(--arm-toast-box-shadow, 0 4px 50px rgb(0 0 0 / 3%));
+  padding: var(--arm-spacing-medium);
+}
+
+/** TOAST ITEM CONTENTS **/
+
+.arm-toast-close {
+  all: unset;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: var(--arm-spacing-xsmall);
+  display: flex;
+  cursor: pointer;
+  color: var(--arm-color-grey-400);
+}
+
+.arm-toast-title {
+  font-size: var(--arm-font-size-large);
+  font-weight: var(--arm-font-weight-medium);
+  margin-bottom: var(--arm-spacing-xxsmall);
+}
+
+.arm-toast-description {
+  color: var(--arm-color-grey-700);
+}
+
+/** TOAST ITEM ANIMATIONS **/
+
+.arm-toast[data-state='open'][data-position="top-right"], .arm-toast[data-state='open'][data-position="bottom-right"] {
+  animation: slideInRight var(--arm-toast-slide-speed, 150ms) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.arm-toast[data-state='open'][data-position="top-left"], .arm-toast[data-state='open'][data-position="bottom-left"] {
+  animation: slideInLeft var(--arm-toast-slide-speed, 150ms) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.arm-toast[data-state='closed'] {
+  animation: hide var(--arm-toast-swipe-speed, 100ms) ease-in;
+}
+
+.arm-toast[data-swipe='move'] {
+  transform: translateX(var(--radix-toast-swipe-move-x));
+}
+
+.arm-toast[data-swipe='cancel'] {
+  transform: translateX(0);
+  transition: transform var(--arm-toast-hide-speed, 200ms) ease-out;
+}
+
+.arm-toast[data-swipe='end'][data-position="top-right"], .arm-toast[data-swipe='end'][data-position="bottom-right"] {
+  animation: swipeOutRight var(--arm-toast-swipe-speed, 100ms) ease-out;
+}
+
+.arm-toast[data-swipe='end'][data-position="top-left"], .arm-toast[data-swipe='end'][data-position="bottom-left"] {
+  animation: swipeOutLeft var(--arm-toast-swipe-speed, 100ms) ease-out;
+}
+
+@keyframes hide {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slideInRight {
+  from {
+    transform: translateX(calc(100% + var(--arm-toast-viewport-padding)));
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideInLeft {
+  from {
+    transform: translateX(calc(-100% + var(--arm-toast-viewport-padding)));
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes swipeOutRight {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+
+  to {
+    transform: translateX(calc(100% + var(--arm-toast-viewport-padding)));
+  }
+}
+
+@keyframes swipeOutLeft {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+
+  to {
+    transform: translateX(calc(-100% + var(--arm-toast-viewport-padding)));
+  }
+}


### PR DESCRIPTION
## What's new?

- Added new Radix toast to module-new
- Created the unified <ArmstrongProvider> to handle toast and global config

## Ticket number(s) in JIRA (if internal)

ARM-318

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [x] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [x] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
