### PR TITLE
InputWrapper, ValidationErrors and Spinner storybook tests

### DIFF
--- a/module-new/src/components/inputWrapper/inputWrapper.stories.mdx
+++ b/module-new/src/components/inputWrapper/inputWrapper.stories.mdx
@@ -1,0 +1,14 @@
+import { ArgTypes, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { InputWrapper } from './inputWrapper.component';
+
+<Meta title="Components/InputWrapper" component={InputWrapper} />
+
+# Input Wrapper
+
+Input wrapper.
+
+<Canvas withSource="open">
+  <Story id="components-inputwrapper--default" />
+</Canvas>
+
+<ArgTypes of={InputWrapper} />

--- a/module-new/src/components/inputWrapper/inputWrapper.stories.mdx
+++ b/module-new/src/components/inputWrapper/inputWrapper.stories.mdx
@@ -5,7 +5,7 @@ import { InputWrapper } from './inputWrapper.component';
 
 # Input Wrapper
 
-Input wrapper.
+Input wrapper used internally by input components.
 
 <Canvas withSource="open">
   <Story id="components-inputwrapper--default" />

--- a/module-new/src/components/inputWrapper/inputWrapper.stories.tsx
+++ b/module-new/src/components/inputWrapper/inputWrapper.stories.tsx
@@ -1,0 +1,101 @@
+import { expect } from '@storybook/jest';
+import { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from '@storybook/testing-library';
+import * as React from 'react';
+
+import { InputWrapper } from './inputWrapper.component';
+
+/** metadata */
+
+export default {
+  title: 'Components/InputWrapper',
+  component: InputWrapper,
+} as Meta<typeof InputWrapper>;
+
+/** component template */
+
+const Template: StoryObj<typeof InputWrapper> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The type discriminator on InputWrapper prevents storybook from spreading pure props on here without a cast
+  render: (props: any) => (
+    <InputWrapper {...props}>
+      <input type="text" />
+    </InputWrapper>
+  ),
+};
+
+/** stories */
+
+export const Default: StoryObj<typeof InputWrapper> = {
+  ...Template,
+  args: {
+    label: 'First Name',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // test input
+    const input = canvas.getByRole('textbox') as HTMLInputElement;
+    const testInputText = 'test input text';
+    userEvent.type(input, testInputText);
+    expect(input.value).toEqual(testInputText);
+
+    // test input wrapper label
+
+    expect(canvas.getByText(args.label as string));
+  },
+};
+
+export const Required: StoryObj<typeof InputWrapper> = {
+  ...Template,
+  args: {
+    label: 'First Name',
+    required: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByText('*'));
+  },
+};
+
+export const Disabled: StoryObj<typeof InputWrapper> = {
+  ...Template,
+  args: {
+    label: 'First Name',
+    disabled: true,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = await canvas.findByText(args.label as string);
+
+    expect(label.parentElement).toHaveAttribute('data-disabled', 'true');
+  },
+};
+
+export const WithOverlays: StoryObj<typeof InputWrapper> = {
+  ...Template,
+  args: {
+    label: 'First Name',
+    leftOverlay: 'Left',
+    rightOverlay: 'Right',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByText(args.leftOverlay as string));
+    expect(canvas.getByText(args.rightOverlay as string));
+  },
+};
+
+export const ValidationError: StoryObj<typeof InputWrapper> = {
+  ...Template,
+  args: {
+    validationMode: 'both',
+    validationErrorMessages: ['This field is required'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByText('This field is required'));
+  },
+};

--- a/module-new/src/components/inputWrapper/inputWrapper.stories.tsx
+++ b/module-new/src/components/inputWrapper/inputWrapper.stories.tsx
@@ -40,8 +40,8 @@ export const Default: StoryObj<typeof InputWrapper> = {
     expect(input.value).toEqual(testInputText);
 
     // test input wrapper label
-
-    expect(canvas.getByText(args.label as string));
+    const label = canvas.getByText(args.label as string);
+    expect(label).toBeVisible();
   },
 };
 
@@ -54,7 +54,8 @@ export const Required: StoryObj<typeof InputWrapper> = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    expect(canvas.getByText('*'));
+    const requiredLabel = canvas.getByText('*');
+    expect(requiredLabel).toBeVisible();
   },
 };
 
@@ -82,8 +83,10 @@ export const WithOverlays: StoryObj<typeof InputWrapper> = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
 
-    expect(canvas.getByText(args.leftOverlay as string));
-    expect(canvas.getByText(args.rightOverlay as string));
+    const leftOverlay = canvas.getByText(args.leftOverlay as string);
+    const rightOverlay = canvas.getByText(args.rightOverlay as string);
+    expect(leftOverlay).toBeVisible();
+    expect(rightOverlay).toBeVisible();
   },
 };
 
@@ -96,6 +99,7 @@ export const ValidationError: StoryObj<typeof InputWrapper> = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    expect(canvas.getByText('This field is required'));
+    const label = canvas.getByText('This field is required');
+    expect(label).toBeVisible();
   },
 };

--- a/module-new/src/components/spinner/spinner.component.tsx
+++ b/module-new/src/components/spinner/spinner.component.tsx
@@ -21,7 +21,13 @@ export const Spinner = React.forwardRef<HTMLDivElement, React.PropsWithChildren<
   ({ children, className, icon, fillContainer, label, ...HTMLProps }, ref) => {
     const { spinnerIcon } = useArmstrongConfig({ spinnerIcon: icon });
     return (
-      <div ref={ref} className={concat('arm-spinner', className)} {...HTMLProps} data-fill-container={fillContainer}>
+      <div
+        ref={ref}
+        className={concat('arm-spinner', className)}
+        {...HTMLProps}
+        data-fill-container={fillContainer}
+        role="status"
+      >
         <div className="arm-spinner-inner">{children || spinnerIcon}</div>
         {label && (
           <div className="arm-spinner-label">

--- a/module-new/src/components/spinner/spinner.stories.tsx
+++ b/module-new/src/components/spinner/spinner.stories.tsx
@@ -56,6 +56,7 @@ export const Labelled: StoryObj<typeof Spinner> = {
 
     expect(spinner).toBeInTheDocument();
 
-    expect(canvas.getByText(args.label as string));
+    const label = canvas.getByText(args.label as string);
+    expect(label).toBeVisible();
   },
 };

--- a/module-new/src/components/spinner/spinner.stories.tsx
+++ b/module-new/src/components/spinner/spinner.stories.tsx
@@ -1,4 +1,6 @@
+import { expect } from '@storybook/jest';
 import { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/testing-library';
 import * as React from 'react';
 import { BiMinusCircle } from 'react-icons/bi';
 
@@ -22,6 +24,12 @@ const Template: StoryObj<typeof Spinner> = {
 
 export const Default: StoryObj<typeof Spinner> = {
   ...Template,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const spinner = canvas.getByRole('status');
+
+    expect(spinner).toBeInTheDocument();
+  },
 };
 
 export const CustomIcon: StoryObj<typeof Spinner> = {
@@ -29,11 +37,25 @@ export const CustomIcon: StoryObj<typeof Spinner> = {
   args: {
     icon: <BiMinusCircle />,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const spinner = canvas.getByRole('status');
+
+    expect(spinner).toBeInTheDocument();
+  },
 };
 
 export const Labelled: StoryObj<typeof Spinner> = {
   ...Template,
   args: {
     label: 'Loading...',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const spinner = canvas.getByRole('status');
+
+    expect(spinner).toBeInTheDocument();
+
+    expect(canvas.getByText(args.label as string));
   },
 };

--- a/module-new/src/components/validationErrors/validationErrors.stories.mdx
+++ b/module-new/src/components/validationErrors/validationErrors.stories.mdx
@@ -1,0 +1,14 @@
+import { ArgTypes, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { ValidationErrors } from './validationErrors.component';
+
+<Meta title="Components/ValidationErrors" component={ValidationErrors} />
+
+# Validation Errors
+
+Component to display validation errors.
+
+<Canvas withSource="open">
+  <Story id="components-validationerrors--default" />
+</Canvas>
+
+<ArgTypes of={ValidationErrors} />

--- a/module-new/src/components/validationErrors/validationErrors.stories.tsx
+++ b/module-new/src/components/validationErrors/validationErrors.stories.tsx
@@ -27,8 +27,10 @@ export const Default: StoryObj<typeof ValidationErrors> = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
 
-    expect(canvas.getByText((args.validationErrors[0] as string) ?? ''));
-    expect(canvas.getByText((args.validationErrors[1] as string) ?? ''));
+    const validationError1 = canvas.getByText((args.validationErrors[0] as string) ?? '');
+    const validationError2 = canvas.getByText((args.validationErrors[1] as string) ?? '');
+    expect(validationError1).toBeVisible();
+    expect(validationError2).toBeVisible();
   },
 };
 

--- a/module-new/src/components/validationErrors/validationErrors.stories.tsx
+++ b/module-new/src/components/validationErrors/validationErrors.stories.tsx
@@ -1,0 +1,41 @@
+import { expect } from '@storybook/jest';
+import { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/testing-library';
+import * as React from 'react';
+
+import { ValidationErrors } from './validationErrors.component';
+
+/** metadata */
+
+export default {
+  title: 'Components/ValidationErrors',
+  component: ValidationErrors,
+  args: { validationErrors: ['This field is required', 'This field requires 12 characters'] },
+} as Meta<typeof ValidationErrors>;
+
+/** component template */
+
+const Template: StoryObj<typeof ValidationErrors> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The type discriminator on ValidationErrors prevents storybook from spreading pure props on here without a cast
+  render: (props: any) => <ValidationErrors {...props} />,
+};
+
+/** stories */
+
+export const Default: StoryObj<typeof ValidationErrors> = {
+  ...Template,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByText((args.validationErrors[0] as string) ?? ''));
+    expect(canvas.getByText((args.validationErrors[1] as string) ?? ''));
+  },
+};
+
+export const Icons: StoryObj<typeof ValidationErrors> = {
+  ...Template,
+  args: {
+    ...Template.args,
+    validationMode: 'icon',
+  },
+};


### PR DESCRIPTION
## What's new?

- Add storybook components for InputWrapper and ValidationErrors
- Add storybook tests for InputWrapper, ValidationErrors and Spinner components

## Ticket number(s) in JIRA (if internal)

ARM-307
ARM-291
ARM-320

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [ ] are any breaking changes documented in `docs/migrating_from_oldstrong.md`?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
- [ ] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
- [ ] are all new SCSS mixins added to `src/theme/mixins.stories.mdx`?
- [ ] are all new SCSS variables added to `src/theme/variables.stories.mdx`?
