### PR TITLE
feat: ARM-311 - Added a "button" display mode to radio group to emu…

### DIFF
--- a/module-new/src/components/radioGroup/radioGroup.component.tsx
+++ b/module-new/src/components/radioGroup/radioGroup.component.tsx
@@ -25,6 +25,9 @@ export interface IRadioGroupProps<Id extends ArmstrongId>
       'scrollValidationErrorsIntoView' | 'validationMode' | 'errorIcon' | 'validationErrorMessages'
     >,
     React.RefAttributes<HTMLDivElement> {
+  /** Whether to show a vertical list of radio buttons or a horizontal set of adjacent buttons */
+  displayMode?: 'radio' | 'button';
+
   /**  prop for binding to an Armstrong form binder (see forms documentation) */
   bind?: IBindingProps<Id>;
 
@@ -86,6 +89,7 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, IRadioGroupProps<Arms
       disabled,
       scrollValidationErrorsIntoView,
       requiredIndicator,
+      displayMode,
       ...nativeProps
     },
     ref
@@ -121,14 +125,16 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, IRadioGroupProps<Arms
           data-error={error || !!validationErrorMessages?.length}
           data-disabled={disabled}
           data-size={displaySize}
+          data-mode={displayMode}
           value={boundValue?.toString() ?? 'undefined'}
           onValueChange={newValue => setBoundValue(newValue)}
           disabled={disabled}
           ref={ref}
           {...nativeProps}
         >
-          {options.map(option => {
+          {options.map((option, i) => {
             const isChecked = boundValue === option.id;
+            const labelContent = getContentFromOption(option, isChecked);
             return (
               <div className="arm-radio-group-item-container" key={option.id}>
                 <RadixRadioGroup.Item
@@ -137,24 +143,32 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, IRadioGroupProps<Arms
                   value={option.id?.toString() ?? ''}
                   id={option.id?.toString()}
                   disabled={option.disabled}
+                  data-checked={isChecked}
+                  data-index={i}
                 >
-                  <RadixRadioGroup.Indicator
-                    className="arm-radio-group-item-indicator"
-                    data-custom-icon={!!customIndicator}
-                  >
-                    {isChecked && customIndicator}
-                  </RadixRadioGroup.Indicator>
+                  {displayMode === 'radio' ? (
+                    <RadixRadioGroup.Indicator
+                      className="arm-radio-group-item-indicator"
+                      data-custom-icon={!!customIndicator}
+                    >
+                      {isChecked && customIndicator}
+                    </RadixRadioGroup.Indicator>
+                  ) : (
+                    labelContent
+                  )}
                 </RadixRadioGroup.Item>
-                <label className="arm-radio-label" htmlFor={option.id?.toString()}>
-                  {getContentFromOption(option, isChecked)}
-                </label>
+                {displayMode === 'radio' && (
+                  <label className="arm-radio-label" htmlFor={option.id?.toString()}>
+                    {labelContent}
+                  </label>
+                )}
               </div>
             );
           })}
-          {bindConfig.shouldShowValidationErrorMessage && bindConfig.validationErrorMessages && (
-            <ValidationErrors validationErrors={bindConfig.validationErrorMessages} className="arm-radio-errors" />
-          )}
         </RadixRadioGroup.Root>
+        {bindConfig.shouldShowValidationErrorMessage && bindConfig.validationErrorMessages && (
+          <ValidationErrors validationErrors={bindConfig.validationErrorMessages} className="arm-radio-errors" />
+        )}
       </>
     );
   }
@@ -162,5 +176,9 @@ export const RadioGroup = React.forwardRef<HTMLDivElement, IRadioGroupProps<Arms
   // DO NOT CHANGE TYPE WITHOUT CHANGING THIS, FIND TYPE BY INSPECTING React.forwardRef
 ) as (<Id extends ArmstrongId>(props: ArmstrongVFCProps<IRadioGroupProps<Id>, HTMLDivElement>) => ArmstrongFCReturn) &
   ArmstrongFCExtensions<IRadioGroupProps<ArmstrongId>>;
+
+RadioGroup.defaultProps = {
+  displayMode: 'radio',
+};
 
 RadioGroup.displayName = 'RadioGroup';

--- a/module-new/src/components/radioGroup/radioGroup.stories.tsx
+++ b/module-new/src/components/radioGroup/radioGroup.stories.tsx
@@ -57,6 +57,47 @@ export const Default: StoryObj<typeof RadioGroup> = {
   },
 };
 
+export const ButtonMode: StoryObj<typeof RadioGroup> = {
+  render: () => {
+    interface IFormData {
+      value?: string;
+    }
+
+    const data: IFormData = { value: undefined };
+
+    const { formProp, formState } = useForm(data);
+
+    return (
+      <>
+        <RadioGroup
+          displayMode="button"
+          bind={formProp('value').bind()}
+          options={[
+            { id: '1', content: 'red' },
+            { id: '2', content: 'blue' },
+            { id: '3', content: 'pink' },
+            { id: '4', content: 'brown' },
+          ]}
+        />
+        <p>Bound value: {formState?.value}</p>
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const result = canvas.getByText('Bound value:');
+    const [red, blue, pink, brown] = await canvas.findAllByRole('radio');
+    userEvent.click(red);
+    await waitFor(() => expect(result).toHaveTextContent('Bound value: 1'));
+    userEvent.click(blue);
+    await waitFor(() => expect(result).toHaveTextContent('Bound value: 2'));
+    userEvent.click(pink);
+    await waitFor(() => expect(result).toHaveTextContent('Bound value: 3'));
+    userEvent.click(brown);
+    await waitFor(() => expect(result).toHaveTextContent('Bound value: 4'));
+  },
+};
+
 export const Disabled: StoryObj<typeof RadioGroup> = {
   render: () => {
     interface IFormData {

--- a/module-new/src/components/radioGroup/radioGroup.theme.css
+++ b/module-new/src/components/radioGroup/radioGroup.theme.css
@@ -5,13 +5,22 @@
   gap: var(--arm-spacing-small);
 }
 
+.arm-radio-group[data-mode='button'] {
+  flex-direction: row;
+  gap: 1px;
+}
+
 .arm-radio-group-item-container {
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
-.arm-radio-group-item {
+.arm-radio-group-item:focus {
+  border-color: var(--arm-color-grey-1000);
+}
+
+.arm-radio-group[data-mode='radio'] .arm-radio-group-item {
   all: unset;
   background-color: white;
   width: var(--arm-spacing-xlarge);
@@ -20,8 +29,26 @@
   border: 1px solid var(--arm-color-grey-600);
 }
 
-.arm-radio-group-item:focus {
-  border-color: var(--arm-color-grey-1000);
+.arm-radio-group[data-mode='button'] .arm-radio-group-item {
+  all: unset;
+  display: inline-flex;
+  padding: var(--arm-spacing-small) var(--arm-spacing-xlarge);
+  border: var(--arm-button-outline-stroke-thickness) solid transparent;
+  align-items: center;
+  font-size: var(--arm-font-size-small);
+  background-color: var(--arm-color-grey-100);
+}
+
+.arm-radio-group[data-mode='button'] .arm-radio-group-item-container:first-of-type {
+  border-top-left-radius: var(--arm-button-border-radius);
+  border-bottom-left-radius: var(--arm-button-border-radius);
+  overflow: hidden;
+}
+
+.arm-radio-group[data-mode='button'] .arm-radio-group-item-container:last-of-type {
+  border-top-right-radius: var(--arm-button-border-radius);
+  border-bottom-right-radius: var(--arm-button-border-radius);
+  overflow: hidden;
 }
 
 .arm-radio-group-item-indicator {
@@ -63,31 +90,31 @@
 
 /** SIZES **/
 
-.arm-radio-group[data-size='small'] {
+.arm-radio-group[data-mode='radio'][data-size='small'] {
   font-size: var(--arm-font-size-xsmall);
   gap: var(--arm-spacing-xxsmall);
 }
 
-.arm-radio-group[data-size='small'] .arm-radio-group-item {
+.arm-radio-group[data-mode='radio'][data-size='small'] .arm-radio-group-item {
   width: var(--arm-spacing-medium);
   height: var(--arm-spacing-medium);
 }
 
-.arm-radio-group[data-size='small'] .arm-radio-label {
+.arm-radio-group[data-mode='radio'][data-size='small'] .arm-radio-label {
   padding-left: var(--arm-spacing-xxsmall);
 }
 
-.arm-radio-group[data-size='large'] {
+.arm-radio-group[data-mode='radio'][data-size='large'] {
   font-size: var(--arm-font-size-medium);
   gap: var(--arm-spacing-medium);
 }
 
-.arm-radio-group[data-size='large'] .arm-radio-group-item {
+.arm-radio-group[data-mode='radio'][data-size='large'] .arm-radio-group-item {
   width: var(--arm-spacing-xxlarge);
   height: var(--arm-spacing-xxlarge);
 }
 
-.arm-radio-group[data-size='large'] .arm-radio-label {
+.arm-radio-group[data-mode='radio'][data-size='large'] .arm-radio-label {
   padding-left: var(--arm-spacing-medium);
 }
 
@@ -95,4 +122,30 @@
 
 .arm-radio-group:not([data-disabled]) .arm-radio-group-item:hover {
   filter: brightness(85%);
+}
+
+/** BUTTON LIST **/
+
+.arm-radio-group[data-mode='button'][data-size='small'] .arm-radio-group-item {
+  padding: var(--arm-spacing-xxsmall) var(--arm-spacing-medium);
+  font-size: var(--arm-font-size-xsmall);
+}
+
+.arm-radio-group[data-mode='button'][data-size='large'] .arm-radio-group-item {
+  padding: var(--arm-spacing-medium) var(--arm-spacing-xxlarge);
+  font-size: var(--arm-font-size-medium);
+}
+
+.arm-radio-group[data-mode='button'] .arm-radio-group-item:disabled {
+  filter: none;
+  opacity: 0.6;
+}
+
+.arm-radio-group[data-mode='button'] .arm-radio-group-item:focus-visible {
+  outline: var(--arm-form-border-thickness-highlight) inset var(--arm-focus-visible-color);
+}
+
+.arm-radio-group[data-mode='button'] .arm-radio-group-item[data-checked='true'] {
+  background-color: var(--arm-button-primary-bg-color);
+  color: var(--arm-button-primary-fg-color);
 }


### PR DESCRIPTION
## What's new?

- Added a "button" display mode to radio group to emulate the old tabSelect component

## Ticket number(s) in JIRA (if internal)

ARM-311

[board](https://rocketmakers.atlassian.net/jira/software/projects/HM/boards/172)

## Checklist

- [x] are your changes in Storybook?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
- [x] are all new hooks added to `src/hooks/hooks.stories.mdx` or given their own docs in Storybook?
