### PR TITLE
Fix: Select placeholder and types

### DIFF
--- a/module/.storybook/manager.ts
+++ b/module/.storybook/manager.ts
@@ -4,8 +4,7 @@ import { create } from '@storybook/theming';
 const armstrongTheme = create({
   base: 'light',
   brandTitle: 'Armstrong Storybook',
-  brandImage:
-    'https://raw.githubusercontent.com/Rocketmakers/armstrong-edge/develop/docs/assets/armstrong-logo.svg',
+  brandImage: 'https://raw.githubusercontent.com/Rocketmakers/armstrong-edge/develop/docs/assets/armstrong-logo.svg',
   brandUrl: 'https://github.com/Rocketmakers/armstrong-edge',
   colorPrimary: '#fe435c',
   colorSecondary: '#ed5d21',

--- a/module/CHANGELOG.md
+++ b/module/CHANGELOG.md
@@ -1,29 +1,25 @@
 ## [3.0.4](https://github.com/Rocketmakers/armstrong-edge/compare/v3.0.3...v3.0.4) (2023-07-14)
 
-
 ### Bug Fixes
 
-* - Added missing provider export ([cc026ec](https://github.com/Rocketmakers/armstrong-edge/commit/cc026ec115025417e272afb2e8693267844a0313))
+- - Added missing provider export ([cc026ec](https://github.com/Rocketmakers/armstrong-edge/commit/cc026ec115025417e272afb2e8693267844a0313))
 
 ## [3.0.3](https://github.com/Rocketmakers/armstrong-edge/compare/v3.0.2...v3.0.3) (2023-07-13)
 
-
 ### Bug Fixes
 
-* - Added missing css export to package file ([8153b3e](https://github.com/Rocketmakers/armstrong-edge/commit/8153b3e785b5fc926d71ea171062860ecd2f98d5))
+- - Added missing css export to package file ([8153b3e](https://github.com/Rocketmakers/armstrong-edge/commit/8153b3e785b5fc926d71ea171062860ecd2f98d5))
 
 ## [3.0.2](https://github.com/Rocketmakers/armstrong-edge/compare/v3.0.1...v3.0.2) (2023-07-11)
 
-
 ### Bug Fixes
 
-* - Another attempted build script fix ([ef9cc85](https://github.com/Rocketmakers/armstrong-edge/commit/ef9cc8548910439e105ca031d6aa27d9eb629b87))
-* - build fixes ([6b18fd1](https://github.com/Rocketmakers/armstrong-edge/commit/6b18fd1b503e7317f5fb884e6d481f59696d79ae))
+- - Another attempted build script fix ([ef9cc85](https://github.com/Rocketmakers/armstrong-edge/commit/ef9cc8548910439e105ca031d6aa27d9eb629b87))
+- - build fixes ([6b18fd1](https://github.com/Rocketmakers/armstrong-edge/commit/6b18fd1b503e7317f5fb884e6d481f59696d79ae))
 
 ## [3.0.1](https://github.com/Rocketmakers/armstrong-edge/compare/v3.0.0...v3.0.1) (2023-07-11)
 
-
 ### Bug Fixes
 
-* - Fixed the readme and some of the build scripts ([efe7fa2](https://github.com/Rocketmakers/armstrong-edge/commit/efe7fa22eea3e274a4e9515eceb951e5f1fcd48a))
-* fixed release script ([44882af](https://github.com/Rocketmakers/armstrong-edge/commit/44882afb22661f8fc7aeaff189e0b7ff314d9eb0))
+- - Fixed the readme and some of the build scripts ([efe7fa2](https://github.com/Rocketmakers/armstrong-edge/commit/efe7fa22eea3e274a4e9515eceb951e5f1fcd48a))
+- fixed release script ([44882af](https://github.com/Rocketmakers/armstrong-edge/commit/44882afb22661f8fc7aeaff189e0b7ff314d9eb0))

--- a/module/src/components/select/select.component.tsx
+++ b/module/src/components/select/select.component.tsx
@@ -95,7 +95,7 @@ export interface ISingleSelectProps<Id extends ArmstrongId>
   /** overrides the aria-label of the input. This is set as default to 'single-select-input' */
   ariaLabel?: string;
 
-  /** overrides the placeholder string in the input when nothing is selected. This is set as default to 'Please select... */
+  /** overrides the placeholder string in the input when nothing is selected. This is set as default to 'Select... */
   placeholder?: string;
 
   /** overrides the error message(s) used in the validation display */
@@ -335,7 +335,11 @@ const ReactSelectComponent = React.forwardRef<
     const selectedValue = React.useMemo(() => {
       const valueFinder = (incomingOptions?: IArmstrongOption<ArmstrongId>[]) => {
         if (!multi) {
-          return incomingOptions?.find(o => o.id === value) ?? { id: value, content: value, wasCreated: true };
+          let singleVal = incomingOptions?.find(o => o.id === value);
+          if (!singleVal && allowCreate) {
+            singleVal = { id: value, content: value, wasCreated: true };
+          }
+          return singleVal;
         }
         return value?.map(
           (v: ArmstrongId) => incomingOptions?.find(o => o.id === v) ?? { id: v, content: v, wasCreated: true }
@@ -345,7 +349,7 @@ const ReactSelectComponent = React.forwardRef<
         return valueFinder(options.map(o => o.options).flat(1));
       }
       return valueFinder(options);
-    }, [multi, options, value]);
+    }, [allowCreate, multi, options, value]);
 
     const valueGetter = React.useCallback<GetOptionValue<IArmstrongOption<ArmstrongId>>>(
       option => {

--- a/module/src/components/select/select.stories.tsx
+++ b/module/src/components/select/select.stories.tsx
@@ -44,7 +44,7 @@ export default {
 /** component template */
 
 const Template: StoryObj<typeof Select> = {
-  args: { options: groupedOptions, placeholder: 'Please select...' },
+  args: { options: groupedOptions },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- The type discriminator on InputWrapper prevents storybook from spreading pure props on here without a cast
   render: (args: any) => {
     const { formProp, formState } = useForm<{ value?: number }>();

--- a/module/src/components/select/select.stories.tsx
+++ b/module/src/components/select/select.stories.tsx
@@ -4,7 +4,7 @@ import { userEvent, waitFor, within } from '@storybook/testing-library';
 import React from 'react';
 
 import { useForm } from '../../form';
-import { Select } from './select.component';
+import { MultiSelect, NativeSelect, Select } from './select.component';
 
 const groupedOptions = [
   {
@@ -105,7 +105,7 @@ export const Native: StoryObj<typeof Select> = {
           height: '20rem',
         }}
       >
-        <Select native={true} options={flatOptions} />
+        <NativeSelect options={flatOptions} />
       </div>
     );
   },
@@ -125,7 +125,7 @@ export const Multi: StoryObj<typeof Select> = {
           height: '20rem',
         }}
       >
-        <Select multi={true} options={flatOptions} bind={formProp('value').bind()} />
+        <MultiSelect options={flatOptions} bind={formProp('value').bind()} />
         <div data-testid="result" style={{ marginTop: '10px' }}>
           Current value: {formState?.value?.join(', ')}
         </div>
@@ -199,8 +199,7 @@ export const CreateMulti: StoryObj<typeof Select> = {
 
     return (
       <div style={{ height: '20rem' }}>
-        <Select
-          multi={true}
+        <MultiSelect
           allowCreate={true}
           bind={formProp('value').bind()}
           options={options}


### PR DESCRIPTION
## What's new?

- Fixed bug causing select placeholder not to work
- Type discrimination on select was complex and broken, now exporting `Select`, `MultiSelect` and `NativeSelect` as separate components.

[board](https://rocketmakers.atlassian.net/jira/software/projects/ARM/boards/154)

## Checklist

- [x] does this work have _all_ the relevant tests?
- [x] are your changes in Storybook?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
