### PR TITLE
"Slot Clone" warning fix

### DIFF
--- a/module/CHANGELOG.md
+++ b/module/CHANGELOG.md
@@ -1,16 +1,14 @@
 ## [3.1.14](https://github.com/Rocketmakers/armstrong-edge/compare/v3.1.13...v3.1.14) (2023-10-24)
 
-
 ### Bug Fixes
 
-* - Fixed a bug causing react select inputs no to deselect when the value is cleared ([ecbca81](https://github.com/Rocketmakers/armstrong-edge/commit/ecbca81006dbdb26913b3578d08fc7f5d7277d39))
+- - Fixed a bug causing react select inputs no to deselect when the value is cleared ([ecbca81](https://github.com/Rocketmakers/armstrong-edge/commit/ecbca81006dbdb26913b3578d08fc7f5d7277d39))
 
 ## [3.1.13](https://github.com/Rocketmakers/armstrong-edge/compare/v3.1.12...v3.1.13) (2023-10-12)
 
-
 ### Bug Fixes
 
-* - Prevented value container remount in select input ([3b676a5](https://github.com/Rocketmakers/armstrong-edge/commit/3b676a5e482fc61b6f3a7c7aabcb053ceaec1665))
+- - Prevented value container remount in select input ([3b676a5](https://github.com/Rocketmakers/armstrong-edge/commit/3b676a5e482fc61b6f3a7c7aabcb053ceaec1665))
 
 ## [3.1.12](https://github.com/Rocketmakers/armstrong-edge/compare/v3.1.11...v3.1.12) (2023-10-12)
 

--- a/module/src/components/checkbox/checkbox.component.tsx
+++ b/module/src/components/checkbox/checkbox.component.tsx
@@ -163,9 +163,7 @@ export const Checkbox = React.forwardRef<HTMLButtonElement, ICheckboxProps<BindT
             onCheckedChange={onCheckedChangeInternal}
             ref={ref}
           >
-            <Indicator className="arm-checkbox-indicator" asChild>
-              {indicator}
-            </Indicator>
+            <Indicator className="arm-checkbox-indicator">{indicator}</Indicator>
           </Root>
 
           {label && (


### PR DESCRIPTION
## What's new?

- Fixed the annoying console warning when interacting with the Checkbox input.