### PR TITLE
fix: adds data attribute to native select so styleable when empty

### DIFF
--- a/module/CHANGELOG.md
+++ b/module/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [3.1.15](https://github.com/Rocketmakers/armstrong-edge/compare/v3.1.14...v3.1.15) (2023-11-17)
 
-
 ### Bug Fixes
 
-* - Fixed the annonying console warning when interacting with the Checkbox input. ([6cfcbcf](https://github.com/Rocketmakers/armstrong-edge/commit/6cfcbcfa620356821a0590bf1fcdbc4c37bd3f22))
+- - Fixed the annonying console warning when interacting with the Checkbox input. ([6cfcbcf](https://github.com/Rocketmakers/armstrong-edge/commit/6cfcbcfa620356821a0590bf1fcdbc4c37bd3f22))
 
 ## [3.1.14](https://github.com/Rocketmakers/armstrong-edge/compare/v3.1.13...v3.1.14) (2023-10-24)
 

--- a/module/src/components/select/select.component.tsx
+++ b/module/src/components/select/select.component.tsx
@@ -636,6 +636,8 @@ export const NativeSelect = React.forwardRef<HTMLSelectElement, INativeSelectPro
         className={concat('arm-select-wrapper', 'arm-select-native-wrapper', className)}
         data-size={displaySize}
         data-error={!bindConfig.isValid}
+        data-disabled={!!disabled}
+        data-empty={!!value}
       >
         {label && (
           <Label


### PR DESCRIPTION
## What's new?

Adds data attribute to native select so styleable when empty