### PR TITLE
Changes the default of the search function on the Select component

### DIFF
--- a/module/src/components/select/select.component.tsx
+++ b/module/src/components/select/select.component.tsx
@@ -181,6 +181,9 @@ export interface ISingleSelectProps<Id extends ArmstrongId>
 
   /** should the input validate automatically against the provided schema? Default: `true` */
   autoValidate?: boolean;
+
+  /** should the search be case sensitive */
+  caseSensitive?: boolean;
 }
 
 export interface INativeSelectProps<Id extends ArmstrongId>
@@ -285,6 +288,7 @@ const ReactSelectComponent = React.forwardRef<
       autoValidate,
       onInputChange,
       inputValue,
+      caseSensitive,
       ...nativeProps
     },
     ref
@@ -389,8 +393,12 @@ const ReactSelectComponent = React.forwardRef<
       (option: FilterOptionOption<IArmstrongOption<ArmstrongId, unknown>>, incomingInputValue: string) => boolean
     >(
       (option, incomingInputValue) => {
-        return !!labelGetter(option.data)?.toString().includes(incomingInputValue);
+        if (caseSensitive) {
+          return !!labelGetter(option.data)?.toString().includes(incomingInputValue);
+        }
+        return !!labelGetter(option.data)?.toString().toLowerCase().includes(incomingInputValue.toLowerCase());
       },
+
       [labelGetter]
     );
 


### PR DESCRIPTION
changes the default of the search function from case sensitive to not and adds in a prop to make it so that you can select if it is or not.

## What's new?

- Added some cool stuff
- Fixed some bad stuff

## Ticket number(s) in JIRA (if internal)

ARM-XX

[board](https://rocketmakers.atlassian.net/jira/software/projects/ARM/boards/154)

## Checklist

- [ ] does this work have _all_ the relevant tests?
- [ ] are your changes in Storybook?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
