### PR TITLE
feat: full key chain

### DIFF
--- a/module/CHANGELOG.md
+++ b/module/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [3.3.1](https://github.com/Rocketmakers/armstrong-edge/compare/v3.3.0...v3.3.1) (2024-02-13)
 
-
 ### Bug Fixes
 
-* optional logging added for schema validation ([a284c00](https://github.com/Rocketmakers/armstrong-edge/commit/a284c003d65882f449c348c5d6296966c471c423))
+- optional logging added for schema validation ([a284c00](https://github.com/Rocketmakers/armstrong-edge/commit/a284c003d65882f449c348c5d6296966c471c423))
 
 # [3.3.0](https://github.com/Rocketmakers/armstrong-edge/compare/v3.2.2...v3.3.0) (2024-01-26)
 

--- a/module/src/form/hooks/useBindingState.spec.ts
+++ b/module/src/form/hooks/useBindingState.spec.ts
@@ -25,6 +25,7 @@ describe('useBindingState', () => {
     allTouched: false,
     validate: jest.fn(),
     isValid: true,
+    fullKeyChain: ['mock', 'key', 'chain'],
   };
 
   it('should return an array with the correct number of elements', () => {

--- a/module/src/form/hooks/useChildForm.spec.ts
+++ b/module/src/form/hooks/useChildForm.spec.ts
@@ -74,4 +74,18 @@ describe('useChildForm', () => {
     expect(result.current.childFormProp('childField2').bind().isTouched).toBe(false);
     expect(result.current.childFormProp('childField3').bind().isTouched).toBe(false);
   });
+
+  it('should return a keyChain property that conforms to the key chain back to the root of the child binder', () => {
+    const { result } = renderHook(() => useTestHook());
+    expect(result.current.childFormProp('childField1').bind().keyChain).toEqual(['childField1']);
+    expect(result.current.childFormProp('childField2').bind().keyChain).toEqual(['childField2']);
+    expect(result.current.childFormProp('childField3').bind().keyChain).toEqual(['childField3']);
+  });
+
+  it('should return a fullKeyChain property that conforms to the full key chain', () => {
+    const { result } = renderHook(() => useTestHook());
+    expect(result.current.childFormProp('childField1').bind().fullKeyChain).toEqual(['childTest', 'childField1']);
+    expect(result.current.childFormProp('childField2').bind().fullKeyChain).toEqual(['childTest', 'childField2']);
+    expect(result.current.childFormProp('childField3').bind().fullKeyChain).toEqual(['childTest', 'childField3']);
+  });
 });

--- a/module/src/form/hooks/useChildForm.ts
+++ b/module/src/form/hooks/useChildForm.ts
@@ -174,6 +174,7 @@ export function useChildForm<TData extends object>(parentBinder?: IBindingProps<
     parseValidationSchema,
     parentBinder?.initialValue,
     parentBinder?.formConfig,
-    parentBinder?.allTouched
+    parentBinder?.allTouched,
+    parentBinder?.fullKeyChain
   );
 }

--- a/module/src/form/hooks/useFormBase.ts
+++ b/module/src/form/hooks/useFormBase.ts
@@ -37,6 +37,8 @@ import { validationErrorsByKeyChain } from '../utils/validation';
  * @param parseValidationSchema The method to trigger validation against the validation schema
  * @param initialDataObject The initial data as passed to the `useForm` hook.
  * @param formConfigObject The configuration as passed to the `useForm` hook.
+ * @param globalTouchOverride Touch state if inherited from a child binder.
+ * @param parentKeyChain The keyChain of the parent binder (passed from `useChildForm`.)
  * @returns The form state, property accessor, and associated helper methods.
  */
 export const useFormBase = <TData extends object>(
@@ -51,7 +53,8 @@ export const useFormBase = <TData extends object>(
   parseValidationSchema: (keyChain?: KeyChain, silent?: boolean) => boolean,
   initialDataObject?: Partial<TData>,
   formConfigObject?: IFormConfig<TData>,
-  globalTouchOverride?: boolean
+  globalTouchOverride?: boolean,
+  parentKeyChain?: KeyChain
 ): HookReturn<TData> => {
   const formConfig = useContentMemo(formConfigObject) as IFormConfig<unknown> | undefined;
   const initialData = useContentMemo(initialDataObject);
@@ -210,6 +213,7 @@ export const useFormBase = <TData extends object>(
         myValidationErrors,
         dispatch,
         keyChain,
+        fullKeyChain: parentKeyChain ? [...parentKeyChain, ...keyChain] : keyChain,
         initialValue: valueByKeyChain(initialData, keyChain),
         addValidationError: (messages: ValidationMessage | ValidationMessage[], identifier?: string) =>
           addValidationErrorFromKeyChain(keyChain, messages, identifier),
@@ -234,20 +238,21 @@ export const useFormBase = <TData extends object>(
     },
     [
       touchedState,
+      combinedValidationErrors,
       formStateLive,
       formConfig,
-      combinedValidationErrors,
       dispatch,
+      parentKeyChain,
       initialData,
       isGlobalTouched,
       globalTouchOverride,
       clientValidationDispatcher,
       touchedStateDispatcher,
+      parseValidationSchema,
       set,
       addValidationErrorFromKeyChain,
       clearValidationErrorsByKeyChain,
       setTouched,
-      parseValidationSchema,
     ]
   );
 

--- a/module/src/form/hooks/useMyValidationErrorMessages.spec.ts
+++ b/module/src/form/hooks/useMyValidationErrorMessages.spec.ts
@@ -25,6 +25,7 @@ describe('useMyValidationErrorMessages', () => {
     allTouched: false,
     validate: jest.fn(),
     isValid: true,
+    fullKeyChain: ['mock', 'key', 'chain'],
   };
 
   it('should return an empty array when no bind or validation error messages are provided', () => {

--- a/module/src/form/types.ts
+++ b/module/src/form/types.ts
@@ -274,8 +274,14 @@ export interface IBindingProps<TValue> {
   dispatch: FormDispatcher<TValue>;
   /**
    * The chain of nesting keys used to access this property from the root of the form data object.
+   * NOTE: This will only go as deep as the nearest `useChildForm`, to return to the parent root, use `fullKeyChain`.
    */
   keyChain: KeyChain;
+  /**
+   * The chain of nesting keys used to access this property from the root of the form data object.
+   * NOTE: This will always go to the root of the form data object, regardless of how many `useChildForm` hooks are in the chain.
+   */
+  fullKeyChain: KeyChain;
   /**
    * An array of current validation errors relating to the targeted property within the form data.
    */


### PR DESCRIPTION
 bind now returns the full keychain back to the root, not just to the root of the child binder
