### PR TITLE
fix: ARM-201 - Additional variables added for form field styling

### DIFF
--- a/module/CHANGELOG.md
+++ b/module/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [3.4.0](https://github.com/Rocketmakers/armstrong-edge/compare/v3.3.1...v3.4.0) (2024-02-15)
 
-
 ### Features
 
-* bind now returns the full keychain back to the root, not just to the root of the child binder ([3a9adfa](https://github.com/Rocketmakers/armstrong-edge/commit/3a9adfabb1dcc3a648b154e2749b04fd12ec930c))
+- bind now returns the full keychain back to the root, not just to the root of the child binder ([3a9adfa](https://github.com/Rocketmakers/armstrong-edge/commit/3a9adfabb1dcc3a648b154e2749b04fd12ec930c))
 
 ## [3.3.1](https://github.com/Rocketmakers/armstrong-edge/compare/v3.3.0...v3.3.1) (2024-02-13)
 

--- a/module/src/components/checkbox/checkbox.theme.css
+++ b/module/src/components/checkbox/checkbox.theme.css
@@ -35,7 +35,7 @@
 }
 
 .arm-checkbox[data-state='unchecked'] {
-  background-color: var(--arm-color-white);
+  background-color: var(--arm-checkbox-bg-color);
 }
 
 .arm-checkbox[data-state='checked'] {

--- a/module/src/components/input/input.theme.css
+++ b/module/src/components/input/input.theme.css
@@ -3,7 +3,7 @@
   min-height: var(--arm-input-height);
   display: flex;
   align-items: center;
-  background-color: var(--arm-color-white);
+  background-color: var(--arm-input-bg-color);
   border: var(--arm-form-border-thickness) solid var(--arm-color-grey-600);
   border-radius: var(--arm-form-border-radius);
   overflow: hidden;
@@ -13,6 +13,7 @@
   width: 100%;
   flex: 1;
   padding: var(--arm-spacing-small) var(--arm-spacing-medium);
+  color: var(--arm-input-fg-color);
   border: none;
   background-color: transparent;
   outline: none;

--- a/module/src/components/radioGroup/radioGroup.theme.css
+++ b/module/src/components/radioGroup/radioGroup.theme.css
@@ -22,7 +22,7 @@
 
 .arm-radio-group[data-mode='radio'] .arm-radio-group-item {
   all: unset;
-  background-color: white;
+  background-color: var(--arm-radio-bg-color);
   width: var(--arm-spacing-xlarge);
   height: var(--arm-spacing-xlarge);
   border-radius: 100%;

--- a/module/src/components/select/select.theme.css
+++ b/module/src/components/select/select.theme.css
@@ -203,7 +203,8 @@
   display: flex;
   border: var(--arm-form-border-thickness) solid var(--arm-color-grey-600);
   border-radius: var(--arm-form-border-radius);
-  background-color: var(--arm-color-white);
+  background-color: var(--arm-input-bg-color);
+  color: var(--arm-input-fg-color);
   min-height: var(--arm-input-height);
 }
 
@@ -218,13 +219,17 @@
 .arm-select-native-wrapper .arm-select-inner {
   border: var(--arm-form-border-thickness) solid var(--arm-color-grey-600);
   border-radius: var(--arm-form-border-radius);
-  background-color: var(--arm-color-white);
+  background-color: var(--arm-input-bg-color);
   width: auto;
   position: relative;
   justify-content: flex-end;
   padding: var(--arm-spacing-small) 0;
   height: 1.5em;
   box-sizing: content-box;
+}
+
+.arm-select-native-wrapper .arm-select-inner select {
+  color: var(--arm-input-fg-color);
 }
 
 .arm-select-native-wrapper .arm-select-inner[data-error-icon='left'] {

--- a/module/src/components/textArea/textArea.theme.css
+++ b/module/src/components/textArea/textArea.theme.css
@@ -4,7 +4,8 @@
   width: var(--arm-input-width);
   min-height: var(--arm-text-area-height, 8rem);
   padding: 1em;
-  background-color: var(--arm-color-white);
+  background-color: var(--arm-input-bg-color);
+  color: var(--arm-input-fg-color);
   border-radius: 6px;
   font-family: inherit;
   font-size: inherit;

--- a/module/src/theme/variables.css
+++ b/module/src/theme/variables.css
@@ -70,6 +70,12 @@
   --arm-input-height: 2.25rem;
   --arm-input-height-medium: 3rem;
   --arm-input-height-large: 3.5rem;
+  --arm-input-bg-color: var(--arm-color-white);
+  --arm-checkbox-bg-color: var(--arm-input-bg-color);
+  --arm-radio-bg-color: var(--arm-input-bg-color);
+  --arm-input-fg-color: inherit;
+  --arm-checkbox-fg-color: var(--arm-input-fg-color);
+  --arm-radio-fg-color: var(--arm-input-fg-color);
 
   /* Spinner */
   --arm-spinner-speed: 500ms;


### PR DESCRIPTION
## What's new?

Added the following variables for additional form styling flexibility:

```
  --arm-input-bg-color: var(--arm-color-white);
  --arm-checkbox-bg-color: var(--arm-input-bg-color);
  --arm-radio-bg-color: var(--arm-input-bg-color);

  --arm-input-fg-color: inherit;
  --arm-checkbox-fg-color: var(--arm-input-fg-color);
  --arm-radio-fg-color: var(--arm-input-fg-color);
```

## Ticket number(s) in JIRA (if internal)

ARM-201

## Checklist

- [x] does this work have _all_ the relevant tests?
- [x] are your changes in Storybook?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
