### PR TITLE
feat: added intro docs and centralised variables + animations

### DIFF
--- a/module/.storybook/preview.tsx
+++ b/module/.storybook/preview.tsx
@@ -28,19 +28,7 @@ export const parameters = {
   },
   options: {
     storySort: {
-      order: [
-        'Setup',
-        'Migration Guides',
-        'Form',
-        'FormUtils',
-        'Button',
-        'Layout',
-        'Display',
-        'Hooks',
-        'SCSS Utilities',
-        'Utilities',
-        'Armstrong Development',
-      ],
+      order: ['Introduction', 'Config', 'Form', 'Components', 'Hooks', 'Modals', 'Utilities'],
     },
   },
   docs: {

--- a/module/CHANGELOG.md
+++ b/module/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [3.5.4](https://github.com/Rocketmakers/armstrong-edge/compare/v3.5.3...v3.5.4) (2024-07-03)
 
-
 ### Bug Fixes
 
-* - Fixed bug causing checkbox to appear disabled when disabled attribute is present regardless of value ([9836885](https://github.com/Rocketmakers/armstrong-edge/commit/983688557a1b1047c26ea229d700a512917456f9))
+- - Fixed bug causing checkbox to appear disabled when disabled attribute is present regardless of value ([9836885](https://github.com/Rocketmakers/armstrong-edge/commit/983688557a1b1047c26ea229d700a512917456f9))
 
 ## [3.5.3](https://github.com/Rocketmakers/armstrong-edge/compare/v3.5.2...v3.5.3) (2024-05-21)
 

--- a/module/src/components/dialog/dialog.theme.css
+++ b/module/src/components/dialog/dialog.theme.css
@@ -1,12 +1,12 @@
 .arm-dialog-overlay {
   position: fixed;
   inset: 0;
-  background-color: var(--arm-dialog-overlay-color, rgb(0 0 0 / 40%));
+  background-color: var(--arm-dialog-overlay-color);
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: var(--arm-dialog-overlay-animation, overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1));
-  z-index: var(--arm-dialog-z-index, 1);
+  animation: var(--arm-dialog-overlay-animation);
+  z-index: var(--arm-dialog-z-index);
 }
 
 .arm-dialog {
@@ -14,16 +14,12 @@
   background-color: var(--arm-color-white);
   padding: var(--arm-spacing-medium);
   padding-bottom: 0;
-  border-radius: var(--arm-dialog-border-radius, var(--arm-button-border-radius));
-  box-shadow: var(
-    --arm-dialog-box-shadow,
-    hsl(206deg 22% 7% / 35%) 0 10px 38px -10px,
-    hsl(206deg 22% 7% / 20%) 0 10px 20px -15px
-  );
-  width: var(--arm-dialog-width, 90vw);
-  max-width: var(--arm-dialog-max-width, 450px);
-  max-height: var(--arm-dialog-max-height, 85vh);
-  animation: var(--arm-dialog-content-animation, contentShow 150ms cubic-bezier(0.16, 1, 0.3, 1));
+  border-radius: var(--arm-dialog-border-radius);
+  box-shadow: var(--arm-dialog-box-shadow);
+  width: var(--arm-dialog-width);
+  max-width: var(--arm-dialog-max-width);
+  max-height: var(--arm-dialog-max-height);
+  animation: var(--arm-dialog-content-animation);
 }
 
 .arm-dialog-close {
@@ -55,26 +51,4 @@
 
 .arm-dialog-content {
   padding-bottom: var(--arm-spacing-medium);
-}
-
-@keyframes overlayShow {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes contentShow {
-  from {
-    opacity: 0;
-    transform: scale(0.96);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
 }

--- a/module/src/components/dropdownMenu/dropdownMenu.theme.css
+++ b/module/src/components/dropdownMenu/dropdownMenu.theme.css
@@ -1,8 +1,4 @@
 .arm-dropdown-menu-content {
-  --arm-dropdown-menu-bg-color: var(--arm-color-white);
-  --arm-dropdown-menu-border-color: var(--arm-color-grey-200);
-  --arm-dropdown-menu-arrow-size: 12px;
-
   min-width: var(--arm-dropdown-menu-min-width, 220px);
   border-radius: 6px;
   padding: var(--arm-spacing-xxsmall) 0;
@@ -24,7 +20,7 @@
 }
 
 .arm-dropdown-menu-content[data-side='top'] {
-  animation-name: var(--arm-dropdown-menu-animation-top, armSlideDownAndFade);
+  animation-name: var(--arm-dropdown-menu-animation-top, arm-slide-down-and-fade);
   margin-bottom: var(--arm-spacing-xxsmall);
 }
 
@@ -39,7 +35,7 @@
 }
 
 .arm-dropdown-menu-content[data-side='right'] {
-  animation-name: var(--arm-dropdown-menu-animation-right, armSlideLeftAndFade);
+  animation-name: var(--arm-dropdown-menu-animation-right, arm-slide-left-and-fade);
   margin-left: var(--arm-spacing-xxsmall);
 }
 
@@ -54,7 +50,7 @@
 }
 
 .arm-dropdown-menu-content[data-side='bottom'] {
-  animation-name: var(--arm-dropdown-menu-animation-bottom, armSlideUpAndFade);
+  animation-name: var(--arm-dropdown-menu-animation-bottom, arm-slide-up-and-fade);
   margin-top: var(--arm-spacing-xxsmall);
 }
 
@@ -69,7 +65,7 @@
 }
 
 .arm-dropdown-menu-content[data-side='left'] {
-  animation-name: var(--arm-dropdown-menu-animation-left, armSlideRightAndFade);
+  animation-name: var(--arm-dropdown-menu-animation-left, arm-slide-right-and-fade);
   margin-right: var(--arm-spacing-xxsmall);
 }
 

--- a/module/src/components/expandable/expandable.theme.css
+++ b/module/src/components/expandable/expandable.theme.css
@@ -5,8 +5,6 @@
 }
 
 .arm-expandable[data-animate='true'] {
-  --arm-expandable-transition-duration: 300ms;
-
   transition-duration: var(--arm-expandable-transition-duration);
   transition-property: height;
 }

--- a/module/src/components/progressBar/progressBar.theme.css
+++ b/module/src/components/progressBar/progressBar.theme.css
@@ -1,9 +1,4 @@
 .arm-progress-bar {
-  --arm-progress-bar-height: 12px;
-  --arm-progress-bar-bg-color: var(--arm-color-grey-100);
-  --arm-progress-bar-fg-color: var(--arm-color-grey-1000);
-  --arm-progress-bar-animation-duration: 200ms;
-
   position: relative;
   overflow: hidden;
   background: var(--arm-progress-bar-bg-color);

--- a/module/src/components/rangeInput/rangeInput.theme.css
+++ b/module/src/components/rangeInput/rangeInput.theme.css
@@ -1,8 +1,4 @@
 .arm-range-input-root {
-  --arm-range-input-width: 600px;
-  --arm-range-input-thumb-size: var(--arm-spacing-xlarge);
-  --arm-range-input-track-height: calc(var(--arm-range-input-thumb-size) / 2);
-
   position: relative;
   display: flex;
   align-items: center;
@@ -52,11 +48,11 @@
 /** SIZES **/
 
 .arm-range-input-root[data-size='small'] {
-  --arm-range-input-width: 400px;
-  --arm-range-input-thumb-size: var(--arm-spacing-medium);
+  --arm-range-input-width: var(--arm-range-input-width-small);
+  --arm-range-input-thumb-size: var(--arm-range-input-thumb-size-small);
 }
 
 .arm-range-input-root[data-size='large'] {
-  --arm-range-input-width: 800px;
-  --arm-range-input-thumb-size: var(--arm-spacing-xxlarge);
+  --arm-range-input-width: var(--arm-range-input-width-large);
+  --arm-range-input-thumb-size: var(--arm-range-input-thumb-size-large);
 }

--- a/module/src/components/rating/rating.stories.tsx
+++ b/module/src/components/rating/rating.stories.tsx
@@ -69,10 +69,14 @@ export const Disabled: StoryObj<typeof Rating> = {
 
 export const Labelled: StoryObj<typeof Rating> = {
   render: () => {
+    const { formProp } = useForm<{ default: NullOrUndefined<number>; required: NullOrUndefined<number> }>({
+      default: 0,
+      required: 0,
+    });
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
-        <Rating label="Default" />
-        <Rating label="Required" required={true} />
+        <Rating label="Default" bind={formProp('default').bind()} />
+        <Rating label="Required" bind={formProp('required').bind()} required={true} />
       </div>
     );
   },
@@ -88,11 +92,20 @@ export const Labelled: StoryObj<typeof Rating> = {
 
 export const Sizes: StoryObj<typeof Rating> = {
   render: () => {
+    const { formProp } = useForm<{
+      small: NullOrUndefined<number>;
+      medium: NullOrUndefined<number>;
+      large: NullOrUndefined<number>;
+    }>({
+      small: 0,
+      medium: 0,
+      large: 0,
+    });
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
-        <Rating label={'Small Rating'} displaySize="small" required={true} />
-        <Rating label={'Medium Rating'} required={true} />
-        <Rating label={'Large Rating'} displaySize="large" required={true} />
+        <Rating label={'Small Rating'} displaySize="small" required={true} bind={formProp('small').bind()} />
+        <Rating label={'Medium Rating'} required={true} bind={formProp('medium').bind()} />
+        <Rating label={'Large Rating'} displaySize="large" required={true} bind={formProp('large').bind()} />
       </div>
     );
   },

--- a/module/src/components/rating/rating.theme.css
+++ b/module/src/components/rating/rating.theme.css
@@ -1,7 +1,3 @@
-.arm-rating {
-  --arm-rating-part-size: 1.8rem;
-}
-
 .arm-rating-input-inner {
   display: flex;
   align-items: center;
@@ -99,9 +95,9 @@
 /* SIZES */
 
 .arm-rating[data-size='small'] {
-  --arm-rating-part-size: 1.2rem;
+  --arm-rating-part-size: var(--arm-rating-part-size-small);
 }
 
 .arm-rating[data-size='large'] {
-  --arm-rating-part-size: 2.4rem;
+  --arm-rating-part-size: var(--arm-rating-part-size-large);
 }

--- a/module/src/components/switch/switch.theme.css
+++ b/module/src/components/switch/switch.theme.css
@@ -13,9 +13,6 @@
 /* SWITCH */
 
 .arm-switch {
-  --arm-switch-width: 2.5rem;
-  --arm-switch-nub-size: 1.5rem;
-
   all: unset;
   width: var(--arm-switch-width);
   height: var(--arm-switch-height, 1.5rem);
@@ -71,13 +68,13 @@
 /** SIZES **/
 
 .arm-switch[data-size='small'] {
-  --arm-switch-width: 2rem;
-  --arm-switch-nub-size: 1.2rem;
-  --arm-switch-height: 1.2rem;
+  --arm-switch-width: var(--arm-switch-width-small);
+  --arm-switch-nub-size: var(--arm-switch-nub-size-small);
+  --arm-switch-height: var(--arm-switch-height-small);
 }
 
 .arm-switch[data-size='large'] {
-  --arm-switch-width: 4rem;
-  --arm-switch-nub-size: 2rem;
-  --arm-switch-height: 2rem;
+  --arm-switch-width: var(--arm-switch-width-large);
+  --arm-switch-nub-size: var(--arm-switch-nub-size-large);
+  --arm-switch-height: var(--arm-switch-height-large);
 }

--- a/module/src/components/toast/toast.theme.css
+++ b/module/src/components/toast/toast.theme.css
@@ -1,8 +1,6 @@
 /** OVERLAY **/
 
 .arm-toast-viewport {
-  --arm-toast-viewport-padding: var(--arm-spacing-xlarge);
-
   position: fixed;
   display: flex;
   flex-direction: column;
@@ -76,16 +74,16 @@
 
 .arm-toast[data-state='open'][data-position='top-right'],
 .arm-toast[data-state='open'][data-position='bottom-right'] {
-  animation: slideInRight var(--arm-toast-slide-speed, 150ms) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: slide-in-right var(--arm-toast-slide-speed) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .arm-toast[data-state='open'][data-position='top-left'],
 .arm-toast[data-state='open'][data-position='bottom-left'] {
-  animation: slideInLeft var(--arm-toast-slide-speed, 150ms) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: slide-in-left var(--arm-toast-slide-speed) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .arm-toast[data-state='closed'] {
-  animation: hide var(--arm-toast-swipe-speed, 100ms) ease-in;
+  animation: hide var(--arm-toast-swipe-speed) ease-in;
 }
 
 .arm-toast[data-swipe='move'] {
@@ -94,65 +92,15 @@
 
 .arm-toast[data-swipe='cancel'] {
   transform: translateX(0);
-  transition: transform var(--arm-toast-hide-speed, 200ms) ease-out;
+  transition: transform var(--arm-toast-hide-speed) ease-out;
 }
 
 .arm-toast[data-swipe='end'][data-position='top-right'],
 .arm-toast[data-swipe='end'][data-position='bottom-right'] {
-  animation: swipeOutRight var(--arm-toast-swipe-speed, 100ms) ease-out;
+  animation: swipe-out-right var(--arm-toast-swipe-speed) ease-out;
 }
 
 .arm-toast[data-swipe='end'][data-position='top-left'],
 .arm-toast[data-swipe='end'][data-position='bottom-left'] {
-  animation: swipeOutLeft var(--arm-toast-swipe-speed, 100ms) ease-out;
-}
-
-@keyframes hide {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes slideInRight {
-  from {
-    transform: translateX(calc(100% + var(--arm-toast-viewport-padding)));
-  }
-
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes slideInLeft {
-  from {
-    transform: translateX(calc(-100% + var(--arm-toast-viewport-padding)));
-  }
-
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes swipeOutRight {
-  from {
-    transform: translateX(var(--radix-toast-swipe-end-x));
-  }
-
-  to {
-    transform: translateX(calc(100% + var(--arm-toast-viewport-padding)));
-  }
-}
-
-@keyframes swipeOutLeft {
-  from {
-    transform: translateX(var(--radix-toast-swipe-end-x));
-  }
-
-  to {
-    transform: translateX(calc(-100% + var(--arm-toast-viewport-padding)));
-  }
+  animation: swipe-out-left var(--arm-toast-swipe-speed) ease-out;
 }

--- a/module/src/components/tooltip/tooltip.theme.css
+++ b/module/src/components/tooltip/tooltip.theme.css
@@ -1,11 +1,6 @@
 /** CONTENT */
 
 .arm-tooltip-content {
-  --arm-tooltip-bg-color: var(--arm-color-grey-800);
-  --arm-tooltip-fg-color: var(--arm-color-white);
-  --arm-tooltip-max-width: 300px;
-  --arm-tooltip-animation-duration: 400ms;
-
   border-radius: 4px;
   padding: var(--arm-spacing-xsmall) var(--arm-spacing-small);
   color: var(--arm-tooltip-fg-color);
@@ -20,19 +15,19 @@
 }
 
 .arm-tooltip-content[data-state='delayed-open'][data-side='top'] {
-  animation-name: armSlideDownAndFade;
+  animation-name: arm-slide-down-and-fade;
 }
 
 .arm-tooltip-content[data-state='delayed-open'][data-side='right'] {
-  animation-name: armSlideLeftAndFade;
+  animation-name: arm-slide-left-and-fade;
 }
 
 .arm-tooltip-content[data-state='delayed-open'][data-side='bottom'] {
-  animation-name: armSlideUpAndFade;
+  animation-name: arm-slide-up-and-fade;
 }
 
 .arm-tooltip-content[data-state='delayed-open'][data-side='left'] {
-  animation-name: armSlideRightAndFade;
+  animation-name: arm-slide-right-and-fade;
 }
 
 .arm-tooltip-arrow {

--- a/module/src/docs/intro.stories.mdx
+++ b/module/src/docs/intro.stories.mdx
@@ -1,0 +1,99 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Introduction/Getting Started" />
+
+# Getting Started
+
+There are three steps to getting a project set up to use Armstrong:
+
+1. Install the package.
+2. Import the stylesheet.
+3. Render your first component.
+
+Optionally, you can also:
+
+4. Wrap your app in the `ArmstrongProvider` to enable global settings and toast notifications.
+5. Override the default global variables.
+
+## 1. Install the package
+
+Install the pacakge using your package manager of choice. For example, with npm:
+
+```bash
+npm install @rocketmakers/armstrong
+```
+
+pnpm:
+
+```bash
+pnpm add @rocketmakers/armstrong
+```
+
+or yarn:
+
+```bash
+yarn add @rocketmakers/armstrong
+```
+
+## 2. Import the stylesheet
+
+We recommend importing the Armstrong stylesheet directly into the `head` element of your HTML file. This gives you full control over the styling import order. Importing the Armstrong styles first will ensure that Armstrong classes can be easily overridden without the need for added speceficity. This can be done like this:
+
+```html
+<link rel="stylesheet" href="/node_modules/@rocketmakers/armstrong/dist/style.css" />
+```
+
+_NOTE: When importing this way, the path to the stylesheet may vary depending on your project setup. Usually, importing from `node_modules` like this will only work if done through a bundler. We recommend [Vite](https://vitejs.dev)._
+
+Aternatively, the import can be done in your main stylesheet like this:
+
+```css
+@import '@rocketmakers/armstrong/css';
+```
+
+## 3. Render your first component
+
+Now you can render your first Armstrong component. For example, a button being rendered in a TypeScript React app:
+
+```tsx
+import React from 'react';
+import { Button } from '@rocketmakers/armstrong';
+
+const App: React.FC = () => {
+  return <Button>Click me</Button>;
+};
+```
+
+## 4. Wrap your app in the `ArmstrongProvider` (optional)
+
+To enable global settings and toast notifications, wrap your app in the `ArmstrongProvider` like this:
+
+```tsx
+import React from 'react';
+import { ArmstrongProvider, Button } from '@rocketmakers/armstrong';
+
+const App: React.FC = () => {
+  return (
+    <ArmstrongProvider>
+      <Button>Click me</Button>
+    </ArmstrongProvider>
+  );
+};
+```
+
+More information on the `ArmstrongProvider` can be found in the [global config documentation](/docs/config-global-config--docs).
+
+## 5. Override the default variables (optional)
+
+To override the default global variables, we recommend creating a new CSS/SCSS file and importing it after the Armstrong styles, then overriding variables inside a `:root` selector. For example:
+
+```css
+:root {
+  --arm-color-brand-primary: #2287c8;
+  --arm-color-brand-secondary: #fdb53f;
+  --arm-font-weight-bold: 600;
+  --arm-color-grey-100: #ebebeb;
+}
+```
+
+A full list of all global CSS variables can be fond in the [CSS variables documentation](/docs/introduction-css-variables--docs).

--- a/module/src/docs/variables.stories.mdx
+++ b/module/src/docs/variables.stories.mdx
@@ -1,0 +1,163 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Introduction/CSS Variables" />
+
+# CSS Variables
+
+The following list of CSS variables are used throughout Armstrong. They are used to define the default values for Armstrong components and can be overridden to customise the look and feel of your app.
+
+## Global Variables
+
+```css
+/* Colors - monochrome */
+--arm-color-black: #000;
+--arm-color-grey-1000: #333;
+--arm-color-grey-900: #474747;
+--arm-color-grey-800: #5c5c5c;
+--arm-color-grey-700: #707070;
+--arm-color-grey-600: #848484;
+--arm-color-grey-500: #999;
+--arm-color-grey-400: #adadad;
+--arm-color-grey-300: #c2c2c2;
+--arm-color-grey-200: #d6d6d6;
+--arm-color-grey-100: #ebebeb;
+--arm-color-white: #fff;
+
+/* Colors - status */
+--arm-color-positive: #27ae60;
+--arm-color-positive-secondary: #27ae5f2b;
+--arm-color-warning: #f78e52;
+--arm-color-warning-secondary: #f78f522b;
+--arm-color-negative: #eb5757;
+--arm-color-negative-secondary: #eb57572b;
+--arm-color-info: #3498d8;
+--arm-color-info-secondary: #3499d82b;
+
+/* Colors - brand */
+--arm-color-brand-primary: #cd3939;
+--arm-color-brand-secondary: #3d4144;
+
+/* Font sizes */
+--arm-font-size-xsmall: 0.875rem;
+--arm-font-size-small: 1rem;
+--arm-font-size-medium: 1.125rem;
+--arm-font-size-large: 1.25rem;
+--arm-font-size-xlarge: 1.5rem;
+--arm-font-size-xxlarge: 2rem;
+--arm-font-size-xxxlarge: 2.5rem;
+
+/** Font weights */
+--arm-font-weight-medium: 500;
+--arm-font-weight-bold: 700;
+
+/* Spacing */
+--arm-spacing-xxxsmall: 0.375rem;
+--arm-spacing-xxsmall: 0.5rem;
+--arm-spacing-xsmall: 0.625rem;
+--arm-spacing-small: 0.75rem;
+--arm-spacing-medium: 1rem;
+--arm-spacing-large: 1.25rem;
+--arm-spacing-xlarge: 1.5rem;
+--arm-spacing-xxlarge: 2rem;
+--arm-spacing-xxxlarge: 2.5rem;
+--arm-spacing-xxxxlarge: 3rem;
+
+/* Accessibility */
+--arm-focus-visible-color: var(--arm-color-grey-1000);
+
+/* Button */
+--arm-button-border-radius: 6px;
+--arm-button-primary-bg-color: var(--arm-color-grey-1000);
+--arm-button-primary-fg-color: var(--arm-color-white);
+--arm-button-secondary-bg-color: var(--arm-color-grey-100);
+--arm-button-secondary-fg-color: var(--arm-color-grey-1000);
+--arm-button-outline-stroke-color: var(--arm-button-primary-bg-color);
+--arm-button-outline-stroke-thickness: 2px;
+
+/* Inputs */
+--arm-input-width: 23.4375rem;
+--arm-input-width-large: 26.25rem;
+--arm-input-height: 2.25rem;
+--arm-input-height-medium: 3rem;
+--arm-input-height-large: 3.5rem;
+
+/* Spinner */
+--arm-spinner-speed: 500ms;
+
+/* Form - shared */
+--arm-form-border-radius: 5px;
+--arm-form-border-thickness: 1px;
+--arm-form-border-thickness-highlight: 1px;
+--arm-form-border-color: var(--arm-color-grey-600);
+--arm-form-square-size: 25px;
+--arm-form-checked-bg-color: var(--arm-color-grey-600);
+--arm-form-checked-fg-color: var(--arm-color-white);
+--arm-form-input-max-width: 23.4375rem;
+
+/* Dropdown menu */
+--arm-dropdown-menu-bg-color: var(--arm-color-white);
+--arm-dropdown-menu-border-color: var(--arm-color-grey-200);
+--arm-dropdown-menu-arrow-size: 12px;
+
+/* Dialog */
+--arm-dialog-overlay-color: rgb(0 0 0 / 40%);
+--arm-dialog-overlay-animation: arm-overlay-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+--arm-dialog-z-index: 1;
+--arm-dialog-border-radius: var(--arm-button-border-radius);
+--arm-dialog-box-shadow: hsl(206deg 22% 7% / 35%) 0 10px 38px -10px, hsl(206deg 22% 7% / 20%) 0 10px 20px -15px;
+--arm-dialog-width: 90vw;
+--arm-dialog-max-width: 450px;
+--arm-dialog-max-height: 85vh;
+--arm-dialog-content-animation: arm-content-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+/* Expandable */
+--arm-expandable-transition-duration: 300ms;
+
+/* Progress bar */
+--arm-progress-bar-height: 12px;
+--arm-progress-bar-bg-color: var(--arm-color-grey-100);
+--arm-progress-bar-fg-color: var(--arm-color-grey-1000);
+--arm-progress-bar-animation-duration: 200ms;
+
+/* Range input */
+--arm-range-input-width: 600px;
+--arm-range-input-thumb-size: var(--arm-spacing-xlarge);
+--arm-range-input-track-height: calc(var(--arm-range-input-thumb-size) / 2);
+--arm-range-input-width-small: 400px;
+--arm-range-input-thumb-size-small: var(--arm-spacing-medium);
+--arm-range-input-width-large: 800px;
+--arm-range-input-thumb-size-large: var(--arm-spacing-xxlarge);
+
+/* Rating input */
+--arm-rating-part-size: 1.8rem;
+--arm-rating-part-size-small: 1.2rem;
+--arm-rating-part-size-large: 2.4rem;
+
+/* Switch input */
+--arm-switch-width: 2.5rem;
+--arm-switch-height: 1.5rem;
+--arm-switch-nub-size: 1.5rem;
+--arm-switch-width-small: 2rem;
+--arm-switch-nub-size-small: 1.2rem;
+--arm-switch-height-small: 1.2rem;
+--arm-switch-width-large: 4rem;
+--arm-switch-nub-size-large: 2rem;
+--arm-switch-height-large: 2rem;
+
+/* Toast */
+--arm-toast-viewport-padding: var(--arm-spacing-xlarge);
+--arm-toast-width: 390px;
+--arm-toast-max-width: 100vw;
+--arm-toast-z-index: 2;
+--arm-toast-border-radius: var(--arm-button-border-radius);
+--arm-toast-box-shadow: 0 4px 50px rgb(0 0 0 / 3%);
+--arm-toast-slide-speed: 150ms;
+--arm-toast-swipe-speed: 100ms;
+--arm-toast-hide-speed: 200ms;
+
+/* Tooltip */
+--arm-tooltip-bg-color: var(--arm-color-grey-800);
+--arm-tooltip-fg-color: var(--arm-color-white);
+--arm-tooltip-max-width: 300px;
+--arm-tooltip-animation-duration: 400ms;
+```

--- a/module/src/theme/animations.css
+++ b/module/src/theme/animations.css
@@ -1,4 +1,4 @@
-@keyframes armSlideUpAndFade {
+@keyframes arm-slide-up-and-fade {
   from {
     opacity: 0;
     transform: translateY(2px);
@@ -10,7 +10,7 @@
   }
 }
 
-@keyframes armSlideRightAndFade {
+@keyframes arm-slide-right-and-fade {
   from {
     opacity: 0;
     transform: translateX(-2px);
@@ -22,7 +22,7 @@
   }
 }
 
-@keyframes armSlideDownAndFade {
+@keyframes arm-slide-down-and-fade {
   from {
     opacity: 0;
     transform: translateY(-2px);
@@ -34,7 +34,7 @@
   }
 }
 
-@keyframes armSlideLeftAndFade {
+@keyframes arm-slide-left-and-fade {
   from {
     opacity: 0;
     transform: translateX(2px);
@@ -43,5 +43,77 @@
   to {
     opacity: 1;
     transform: translateX(0);
+  }
+}
+
+@keyframes arm-overlay-show {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes arm-content-show {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes hide {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slide-in-right {
+  from {
+    transform: translateX(calc(100% + var(--arm-toast-viewport-padding)));
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-left {
+  from {
+    transform: translateX(calc(-100% + var(--arm-toast-viewport-padding)));
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes swipe-out-right {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+
+  to {
+    transform: translateX(calc(100% + var(--arm-toast-viewport-padding)));
+  }
+}
+
+@keyframes swipe-out-left {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+
+  to {
+    transform: translateX(calc(-100% + var(--arm-toast-viewport-padding)));
   }
 }

--- a/module/src/theme/variables.css
+++ b/module/src/theme/variables.css
@@ -83,4 +83,71 @@
   --arm-form-checked-bg-color: var(--arm-color-grey-600);
   --arm-form-checked-fg-color: var(--arm-color-white);
   --arm-form-input-max-width: 23.4375rem;
+
+  /* Dropdown menu */
+  --arm-dropdown-menu-bg-color: var(--arm-color-white);
+  --arm-dropdown-menu-border-color: var(--arm-color-grey-200);
+  --arm-dropdown-menu-arrow-size: 12px;
+
+  /* Dialog */
+  --arm-dialog-overlay-color: rgb(0 0 0 / 40%);
+  --arm-dialog-overlay-animation: arm-overlay-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  --arm-dialog-z-index: 1;
+  --arm-dialog-border-radius: var(--arm-button-border-radius);
+  --arm-dialog-box-shadow: hsl(206deg 22% 7% / 35%) 0 10px 38px -10px, hsl(206deg 22% 7% / 20%) 0 10px 20px -15px;
+  --arm-dialog-width: 90vw;
+  --arm-dialog-max-width: 450px;
+  --arm-dialog-max-height: 85vh;
+  --arm-dialog-content-animation: arm-content-show 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Expandable */
+  --arm-expandable-transition-duration: 300ms;
+
+  /* Progress bar */
+  --arm-progress-bar-height: 12px;
+  --arm-progress-bar-bg-color: var(--arm-color-grey-100);
+  --arm-progress-bar-fg-color: var(--arm-color-grey-1000);
+  --arm-progress-bar-animation-duration: 200ms;
+
+  /* Range input */
+  --arm-range-input-width: 600px;
+  --arm-range-input-thumb-size: var(--arm-spacing-xlarge);
+  --arm-range-input-track-height: calc(var(--arm-range-input-thumb-size) / 2);
+  --arm-range-input-width-small: 400px;
+  --arm-range-input-thumb-size-small: var(--arm-spacing-medium);
+  --arm-range-input-width-large: 800px;
+  --arm-range-input-thumb-size-large: var(--arm-spacing-xxlarge);
+
+  /* Rating input */
+  --arm-rating-part-size: 1.8rem;
+  --arm-rating-part-size-small: 1.2rem;
+  --arm-rating-part-size-large: 2.4rem;
+
+  /* Switch input */
+  --arm-switch-width: 2.5rem;
+  --arm-switch-height: 1.5rem;
+  --arm-switch-nub-size: 1.5rem;
+  --arm-switch-width-small: 2rem;
+  --arm-switch-nub-size-small: 1.2rem;
+  --arm-switch-height-small: 1.2rem;
+  --arm-switch-width-large: 4rem;
+  --arm-switch-nub-size-large: 2rem;
+  --arm-switch-height-large: 2rem;
+
+  /* Toast */
+  --arm-toast-viewport-padding: var(--arm-spacing-xlarge);
+  --arm-toast-width: 390px;
+  --arm-toast-max-width: 100vw;
+  --arm-toast-z-index: 2;
+  --arm-toast-border-radius: var(--arm-button-border-radius);
+  --arm-toast-box-shadow: 0 4px 50px rgb(0 0 0 / 3%);
+  --arm-toast-slide-speed: 150ms;
+  --arm-toast-swipe-speed: 100ms;
+  --arm-toast-hide-speed: 200ms;
+
+  /* Tooltip */
+  --arm-tooltip-bg-color: var(--arm-color-grey-800);
+  --arm-tooltip-fg-color: var(--arm-color-white);
+  --arm-tooltip-max-width: 300px;
+  --arm-tooltip-animation-duration: 400ms;
 }


### PR DESCRIPTION
## What's new?

- Added "Getting started" guide to Storybook docs.
- Added list of variables to Storybook docs.
- Centralised all CSS variable declarations to root level for consistency.
- Moved all animations to animations.css file for consistency.
- Renamed animations to correct casing (technically a breaking change, but I highly doubt any code outside of Armstrong is using these animations, it's not worth a v4.)
- Fixed issue in rating input stories causing some examples not to work.
- Fixed order of story groups to more logical order.

## Checklist

- [x] does this work have _all_ the relevant tests?
- [x] are your changes in Storybook?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
