### PR TITLE
feat: - Added additional config options to avoid toast duplication

### DIFF
--- a/module/CHANGELOG.md
+++ b/module/CHANGELOG.md
@@ -7,10 +7,9 @@
 
 ## [3.10.2](https://github.com/Rocketmakers/armstrong-edge/compare/v3.10.1...v3.10.2) (2025-03-26)
 
-
 ### Bug Fixes
 
-* - Resolves issue with nested arrays in IValidationSchema ([fd791fd](https://github.com/Rocketmakers/armstrong-edge/commit/fd791fd03f18c96581411624a2e5d52dd5caa9f8))
+- - Resolves issue with nested arrays in IValidationSchema ([fd791fd](https://github.com/Rocketmakers/armstrong-edge/commit/fd791fd03f18c96581411624a2e5d52dd5caa9f8))
 
 ## [3.10.1](https://github.com/Rocketmakers/armstrong-edge/compare/v3.10.0...v3.10.1) (2025-02-25)
 

--- a/module/src/components/config/config.context.tsx
+++ b/module/src/components/config/config.context.tsx
@@ -6,10 +6,10 @@ import { ImMinus, ImSpinner2 } from 'react-icons/im';
 import { IoIosWarning } from 'react-icons/io';
 import { RiCloseLine } from 'react-icons/ri';
 
-import { DisplaySize } from '../../types';
+import { DisplaySize, ToastDisplayMode } from '../../types';
 import { stripNullOrUndefined } from '../../utils/objects';
 import type { ButtonDisplayStyle } from '../button';
-import type { ToastPosition } from '../toast';
+import type { IToast, ToastPosition } from '../toast';
 
 /**
  * Armstrong global config type
@@ -66,6 +66,12 @@ export interface IArmstrongConfig {
   /** the icon to use for the dialog close button */
   toastCloseButtonIcon?: JSX.Element | false;
 
+  /** whether to add toasts to a stack or display one at a time */
+  toastDisplayMode?: ToastDisplayMode;
+
+  /** ignore toasts if an existing toast matches this predicate */
+  toastIgnorePredicate?: (existingToasts: IToast[], incomingToast: IToast) => boolean;
+
   /** A custom JSX.Element for the checked indicator. (Optional) */
   checkboxCustomIndicator?: JSX.Element;
 
@@ -85,8 +91,8 @@ export interface IArmstrongConfig {
   autoValidate?: boolean;
 }
 
-type ArmstrongConfigDefaults = Required<Omit<IArmstrongConfig, 'globalPortalTo'>> &
-  Pick<IArmstrongConfig, 'globalPortalTo'>;
+type ArmstrongConfigDefaults = Required<Omit<IArmstrongConfig, 'globalPortalTo' | 'toastIgnorePredicate'>> &
+  Pick<IArmstrongConfig, 'globalPortalTo' | 'toastIgnorePredicate'>;
 
 /**
  * System level defaults for armstrong global config
@@ -109,6 +115,7 @@ const systemDefaults: ArmstrongConfigDefaults = {
   toastDuration: 5000,
   toastPosition: 'bottom-right',
   toastCloseButtonIcon: <RiCloseLine size={18} />,
+  toastDisplayMode: 'add',
   checkboxCustomIndicator: <FaCheck />,
   checkboxCustomIndeterminateIndicator: <ImMinus />,
   tooltipDelay: 700,

--- a/module/src/components/toast/toast.component.tsx
+++ b/module/src/components/toast/toast.component.tsx
@@ -12,6 +12,9 @@ export interface IToastProps extends IToast {
 
   /** the icon to use for the dialog close button */
   closeButtonIcon: JSX.Element | false;
+
+  /** called when the toast has left the screen */
+  onExit?: () => void;
 }
 
 export const Toast: React.FC<IToastProps> = ({
@@ -24,6 +27,7 @@ export const Toast: React.FC<IToastProps> = ({
   hideClose,
   className,
   testId,
+  onExit,
   additionalProps = {},
 }) => {
   return (
@@ -33,6 +37,11 @@ export const Toast: React.FC<IToastProps> = ({
       data-position={position}
       data-testid={testId}
       aria-label="Notification"
+      onOpenChange={open => {
+        if (!open && onExit) {
+          onExit();
+        }
+      }}
       {...additionalProps}
     >
       {title && <RadixToast.Title className="arm-toast-title">{title}</RadixToast.Title>}

--- a/module/src/components/toast/toast.mdx
+++ b/module/src/components/toast/toast.mdx
@@ -63,3 +63,37 @@ export const MyApp: React.FC<React.PropsWithChildren> = ({ children }) => {
 ```
 
 NOTE: These settings can also be passed in as props to the `<ToastProvider>` if you're using that, and `duration` can also be set on a per-toast basis
+
+## ToastProvider Props
+
+The `ToastProvider` component supplies the context and configuration for displaying toast notifications globally.
+
+### `duration`
+
+- **Type**: `number`
+- **Default**: `5000`
+- Specifies how long a toast remains visible (in milliseconds) before auto-dismissal.
+
+### `position`
+
+- **Type**: `'top-left' | 'top-right' | 'bottom-right' | 'bottom-left'`
+- **Default**: `'bottom-right'`
+- Controls where toast notifications appear on the screen.
+
+### `closeButtonIcon`
+
+- **Type**: `JSX.Element | false`
+- **Default**: `undefined`
+- Defines a custom icon for the close button. Use `false` to hide the close button entirely.
+
+### `displayMode`
+
+- **Type**: `'add' | 'replace'`
+- **Default**: `'add'`
+- Determines whether new toasts are stacked (`'add'`) or replace the current toast (`'replace'`).
+
+### `ignorePredicate`
+
+- **Type**: `(existingToasts: IToast[], incomingToast: IToast) => boolean`
+- **Default**: `undefined`
+- If defined, prevents a new toast from being added if the function returns `true`. Useful for deduplication.

--- a/module/src/components/toast/toast.stories.tsx
+++ b/module/src/components/toast/toast.stories.tsx
@@ -156,3 +156,46 @@ export const CustomContent: StoryObj<typeof Toast> = {
     expect(customButton).toBeVisible();
   },
 };
+
+export const IgnoreDuplicateToast: StoryObj<typeof Toast> = {
+  ...Template,
+  decorators: [
+    Story => (
+      <ArmstrongProvider
+        config={{
+          toastIgnorePredicate: (existing, incoming) =>
+            existing.some(t => t.title === incoming.title && t.description === incoming.description),
+        }}
+      >
+        <Story />
+      </ArmstrongProvider>
+    ),
+  ],
+  play: async ({ canvasElement, args }) => {
+    const button = within(canvasElement).getByText('Send a toast');
+    await userEvent.click(button);
+    await userEvent.click(button); // should be ignored
+
+    const toasts = await findAllByText(document.body, args.title ?? '');
+    expect(toasts.length).toBe(1);
+  },
+};
+
+export const ReplaceDisplayMode: StoryObj<typeof Toast> = {
+  ...Template,
+  decorators: [
+    Story => (
+      <ArmstrongProvider config={{ toastDisplayMode: 'replace' }}>
+        <Story />
+      </ArmstrongProvider>
+    ),
+  ],
+  play: async ({ canvasElement, args }) => {
+    const button = within(canvasElement).getByText('Send a toast');
+    await userEvent.click(button);
+    await userEvent.click(button); // should replace the previous toast
+
+    const toasts = await findAllByText(document.body, args.title ?? '');
+    expect(toasts.length).toBe(1);
+  },
+};

--- a/module/src/types/core.ts
+++ b/module/src/types/core.ts
@@ -46,3 +46,8 @@ export type CustomString = `custom-${string}`;
  * Display type options for inputs
  */
 export type DisplaySize = 'small' | 'medium' | 'large' | CustomString;
+
+/**
+ * Display mode for toast provider
+ */
+export type ToastDisplayMode = 'add' | 'replace';


### PR DESCRIPTION
## Added additional config options to avoid toast duplication

- Added `ignorePredicate` to allow custom logic for ignoring duplicate toasts
- Added `displayMode` option to control whether toasts are stacked or replaced
- Updated ToastProvider to respect new configuration via ArmstrongProvider
- Added Storybook stories to demonstrate and test both new props
- Wrote Playwright tests for `ignorePredicate` and `displayMode`
- Expanded Storybook documentation to cover all `ToastProvider` props

## Checklist

- [x] does this work have _all_ the relevant tests?
- [x] are your changes in Storybook?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?