### PR TITLE
feat: allowed passing radix's modal prop to the dropdown

### DIFF
--- a/module/src/components/dropdownMenu/dropdownMenu.component.tsx
+++ b/module/src/components/dropdownMenu/dropdownMenu.component.tsx
@@ -55,7 +55,7 @@ export interface IDropdownMenuItem {
 export interface IDropdownMenuProps
   extends React.DetailedHTMLProps<React.HTMLProps<HTMLDivElement>, HTMLDivElement>,
     Pick<React.ComponentProps<typeof RadixDropdownMenu['Content']>, 'side' | 'align' | 'sticky'>,
-    Pick<React.ComponentProps<typeof RadixDropdownMenu['Root']>, 'open' | 'defaultOpen' | 'onOpenChange'> {
+    Pick<React.ComponentProps<typeof RadixDropdownMenu['Root']>, 'open' | 'defaultOpen' | 'onOpenChange' | 'modal'> {
   /**
    * Array of dropdown menu items, or a custom React node to render.
    */
@@ -90,6 +90,7 @@ export const DropdownMenu = React.forwardRef<HTMLDivElement, React.PropsWithChil
       footerContent,
       headerContent,
       disabled,
+      modal,
       ...nativeProps
     },
     ref
@@ -146,7 +147,12 @@ export const DropdownMenu = React.forwardRef<HTMLDivElement, React.PropsWithChil
     }, [items]);
 
     return (
-      <RadixDropdownMenu.Root open={internalOpen} onOpenChange={onOpenChangeInner} defaultOpen={defaultOpen}>
+      <RadixDropdownMenu.Root
+        open={internalOpen}
+        onOpenChange={onOpenChangeInner}
+        defaultOpen={defaultOpen}
+        modal={modal}
+      >
         {children && (
           <RadixDropdownMenu.Trigger asChild disabled={disabled}>
             {children}

--- a/module/src/components/dropdownMenu/dropdownMenu.stories.tsx
+++ b/module/src/components/dropdownMenu/dropdownMenu.stories.tsx
@@ -1,7 +1,6 @@
-import { expect } from '@storybook/test';
 import * as test from '@storybook/test';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
 import { Meta, StoryObj } from '@storybook/react';
-import { userEvent, waitFor, within } from '@storybook/test';
 import * as React from 'react';
 import { ImCheckmark, ImUser } from 'react-icons/im';
 
@@ -246,5 +245,49 @@ export const CustomContent: StoryObj<typeof DropdownMenu> = {
 
     const customContent = within(canvas.getByTestId('dropdown')).getByTestId('custom-content');
     expect(customContent).toBeVisible();
+  },
+};
+
+export const Modal: StoryObj<typeof DropdownMenu> = {
+  render: () => {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: '16px',
+        }}
+      >
+        <DropdownMenu items={<div data-testid={'item-1'}>Item 1</div>} data-testid="dropdown-1" modal={false}>
+          <Button type="button" data-testid="button-1">
+            None Modal Dropdown
+          </Button>
+        </DropdownMenu>
+        <DropdownMenu items={<div data-testid={'item-2'}>Item 2</div>} data-testid="dropdown-2" modal={false}>
+          <Button type="button" data-testid="button-2">
+            Another None Modal Dropdown
+          </Button>
+        </DropdownMenu>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const openButton1 = canvas.getByTestId('button-1');
+    userEvent.click(openButton1);
+
+    await waitFor(() => expect(canvas.getByTestId('dropdown-1')).toBeVisible());
+
+    const item1 = within(canvas.getByTestId('dropdown-1')).getByTestId('item-1');
+    expect(item1).toBeVisible();
+
+    const openButton2 = canvas.getByTestId('button-2');
+    userEvent.click(openButton2);
+    await waitFor(() => expect(canvas.getByTestId('dropdown-2')).toBeVisible());
+    const item2 = within(canvas.getByTestId('dropdown-2')).getByTestId('item-2');
+    expect(item2).toBeVisible();
+
+    expect(item1).not.toBeVisible();
   },
 };


### PR DESCRIPTION
## What's new?

Allowed passing radix's modal prop to the dropdown.

This allows the user to click on another dropdown menu without having to first click to close an open dropdown menu

## Checklist

- [x] does this work have _all_ the relevant tests?
- [x] are your changes in Storybook?
- [x] does _everything_ have jsdoc?
- [x] is everything exported from index.ts?
