### PR TITLE
fix: fixed keychain string creation for keychains with zeros

### DIFF
--- a/module/src/form/utils/keyChain.spec.ts
+++ b/module/src/form/utils/keyChain.spec.ts
@@ -2,6 +2,7 @@ import {
   childKeyChainStringFromParent,
   isArrayValue,
   isMyKeyChainItem,
+  isValidPropertyKey,
   keyStringFromKeyChain,
   mergeDeepFromKeyChain,
   valueByKeyChain,
@@ -201,6 +202,38 @@ describe('isArrayValue', () => {
     expect(() => isArrayValue(value, 'action')).toThrow(
       '"action" cannot be used on a set form property that does not contain an array value, the current value of this property is: "foo"'
     );
+  });
+});
+
+describe('isValidPropertyKey', () => {
+  it('returns true for a valid string key', () => {
+    const key = 'validKey';
+    const result = isValidPropertyKey(key);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns true for a valid number key', () => {
+    const key = 123;
+    const result = isValidPropertyKey(key);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns true for 0 as a valid number key', () => {
+    const key = 0;
+    const result = isValidPropertyKey(key);
+    expect(result).toBeTruthy();
+  });
+
+  it('returns false for an empty string key', () => {
+    const key = '';
+    const result = isValidPropertyKey(key);
+    expect(result).toBeFalsy();
+  });
+
+  it('returns false for undefined key', () => {
+    const key = undefined;
+    const result = isValidPropertyKey(key);
+    expect(result).toBeFalsy();
   });
 });
 

--- a/module/src/form/utils/keyChain.spec.ts
+++ b/module/src/form/utils/keyChain.spec.ts
@@ -212,6 +212,12 @@ describe('keyStringFromKeyChain', () => {
     expect(result).toBe('test.value.3.target');
   });
 
+  it('converts a keychain to dot notation to target an item stored by keychain string when the keychain containes a zero', () => {
+    const keyChain = ['test', 'value', 0, 'target'];
+    const result = keyStringFromKeyChain(keyChain, 'dots');
+    expect(result).toBe('test.value.0.target');
+  });
+
   it('converts a keychain to bracket notation to target an item stored by keychain string', () => {
     const keyChain = ['test', 'value', 3, 'target'];
     const result = keyStringFromKeyChain(keyChain, 'brackets');

--- a/module/src/form/utils/keyChain.ts
+++ b/module/src/form/utils/keyChain.ts
@@ -110,6 +110,15 @@ export function isArrayValue(value: unknown, attemptedAction: string): value is 
 }
 
 /**
+ * Checks a possible keyChain to make sure it is a valid keyChain.
+ * @param keyChain The keyChain to check.
+ * @returns true if the keyChain is valid, false if not.
+ */
+export function isValidPropertyKey(propertyKey: PropertyKey | undefined): propertyKey is PropertyKey {
+  return typeof propertyKey === 'number' || (typeof propertyKey === 'string' && propertyKey.length > 0);
+}
+
+/**
  * Converts a keyChain into a key string
  * @param keyChain The chain of keys passed to `formProp` and used to access the property within a nested form object.
  * @param mode (dots|brackets) Whether to use dot syntax for array indexes, or square brackets.
@@ -118,7 +127,7 @@ export function isArrayValue(value: unknown, attemptedAction: string): value is 
 export function keyStringFromKeyChain(keyChain: KeyChain | undefined, mode: 'dots' | 'brackets'): string {
   switch (mode) {
     case 'dots':
-      return keyChain?.filter(key => key !== undefined && key !== null).join('.') ?? '';
+      return keyChain?.filter(isValidPropertyKey).join('.') ?? '';
     case 'brackets':
       return (
         keyChain?.reduce<string>((attrString, key) => {

--- a/module/src/form/utils/keyChain.ts
+++ b/module/src/form/utils/keyChain.ts
@@ -118,7 +118,7 @@ export function isArrayValue(value: unknown, attemptedAction: string): value is 
 export function keyStringFromKeyChain(keyChain: KeyChain | undefined, mode: 'dots' | 'brackets'): string {
   switch (mode) {
     case 'dots':
-      return keyChain?.filter(key => !!key).join('.') ?? '';
+      return keyChain?.filter(key => key !== undefined && key !== null).join('.') ?? '';
     case 'brackets':
       return (
         keyChain?.reduce<string>((attrString, key) => {


### PR DESCRIPTION
## What's new?

- Fixed a bug causing the first form item in an array to show an error message if any other form items had an error.


## Checklist

- [X] does this work have _all_ the relevant tests?
- [ ] are your changes in Storybook?
- [ ] does _everything_ have jsdoc?
- [ ] is everything exported from index.ts?
